### PR TITLE
fix: Broken image fallback & a11y for Blog/Project cards

### DIFF
--- a/src/components/blogs/BlogCard.tsx
+++ b/src/components/blogs/BlogCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { ArrowRight, Calendar, Clock, Eye, Heart } from 'lucide-react'
-import { Link } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
@@ -14,9 +14,17 @@ interface BlogCardProps {
 }
 
 export default function BlogCard({ blog, index }: BlogCardProps) {
+  const navigate = useNavigate()
   const [views, setViews] = useState(0)
   const [likes, setLikes] = useState(0)
-  const animationDelay = `${120 + index * 100}ms`
+  const [imgError, setImgError] = useState(false)
+  const animationDelay = `${60 + index * 50}ms`
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    // Don't navigate if user clicked the title link itself or is selecting text
+    if ((e.target as HTMLElement).closest('a')) return
+    navigate(`/blogs/${blog.slug}`)
+  }
 
   useEffect(() => {
     getBlogViews(blog.slug).then(setViews)
@@ -33,24 +41,39 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
 
   return (
     <Card
+      role="article"
+      aria-label={blog.title}
+      onClick={handleCardClick}
       className={cn(
-        'group border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60 transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-300/70 hover:bg-slate-900/90 light:hover:bg-white/90 overflow-hidden',
+        'group cursor-pointer border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60 transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-300/70 hover:bg-slate-900/90 light:hover:bg-white/90 overflow-hidden',
       )}
       style={{
-        animation: 'fade-in 900ms ease-out both',
+        animation: 'fade-in 400ms ease-out both',
         animationDelay,
       }}
     >
       <div className="flex flex-col md:flex-row gap-4 p-4 md:p-6">
         {blog.image && (
-          <div className="relative w-full md:w-48 lg:w-64 flex-shrink-0 h-48 md:h-40 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60">
-            <img
-              src={blog.image}
-              alt={blog.title}
-              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-              loading="lazy"
-              decoding="async"
-            />
+          <div className="relative w-full md:w-48 lg:w-64 flex-shrink-0 h-48 md:h-40 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-800/40 light:bg-slate-100/60">
+            {imgError ? (
+              <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
+                <span
+                  className="text-center text-xs text-slate-400 light:text-slate-500 line-clamp-3"
+                  style={{ fontFamily: 'var(--font-body)', fontWeight: 500 }}
+                >
+                  {blog.title}
+                </span>
+              </div>
+            ) : (
+              <img
+                src={blog.image}
+                alt={blog.title}
+                className="h-full w-full object-cover"
+                loading="lazy"
+                decoding="async"
+                onError={() => setImgError(true)}
+              />
+            )}
           </div>
         )}
         <div className="flex-1 space-y-3">
@@ -69,16 +92,21 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
                 </Badge>
               </div>
               <h3
-                className="text-lg md:text-xl text-slate-300 light:text-slate-800"
+                className="text-lg md:text-xl"
                 style={{
                   fontFamily: 'var(--font-mono)',
                   fontWeight: 600,
                 }}
               >
-                {blog.title}
+                <Link
+                  to={`/blogs/${blog.slug}`}
+                  className="text-slate-300 light:text-slate-800 hover:text-slate-100 light:hover:text-slate-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 rounded-sm"
+                >
+                  {blog.title}
+                </Link>
               </h3>
               <p
-                className="text-sm line-clamp-2 text-slate-400 light:text-slate-600"
+                className="text-sm line-clamp-2 text-slate-300 light:text-slate-600"
                 style={{
                   fontFamily: 'var(--font-body)',
                   fontWeight: 400,
@@ -96,9 +124,9 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
                 {blog.author.name.charAt(0).toUpperCase()}
               </AvatarFallback>
             </Avatar>
-            <div className="flex-1 flex flex-wrap items-center gap-3 text-xs text-slate-400 light:text-slate-600">
+            <div className="flex-1 flex flex-wrap items-center gap-3 text-xs text-slate-300 light:text-slate-600">
               <span
-                className="text-slate-300 light:text-slate-800"
+                className="text-slate-200 light:text-slate-800"
                 style={{
                   fontFamily: 'var(--font-body)',
                   fontWeight: 500,
@@ -106,8 +134,8 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
               >
                 {blog.author.name}
               </span>
-              <div className="flex items-center gap-1">
-                <Calendar className="h-3 w-3 text-slate-400 light:text-slate-600" />
+              <div className="flex items-center gap-1" aria-label={`Published ${formatDate(blog.date)}`}>
+                <Calendar className="h-3 w-3" aria-hidden="true" />
                 <span
                   style={{
                     fontFamily: 'var(--font-body)',
@@ -117,8 +145,8 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
                   {formatDate(blog.date)}
                 </span>
               </div>
-              <div className="flex items-center gap-1">
-                <Clock className="h-3 w-3 text-slate-400 light:text-slate-600" />
+              <div className="flex items-center gap-1" aria-label={`${blog.readTime || 5} minute read`}>
+                <Clock className="h-3 w-3" aria-hidden="true" />
                 <span
                   style={{
                     fontFamily: 'var(--font-body)',
@@ -128,26 +156,26 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
                   {blog.readTime || 5} min read
                 </span>
               </div>
-              <div className="flex items-center gap-1">
-                <Eye className="h-3 w-3 text-slate-400 light:text-slate-600" />
+              <div className="flex items-center gap-1" aria-label={`${views.toLocaleString()} views`}>
+                <Eye className="h-3 w-3" aria-hidden="true" />
                 <span
                   style={{
                     fontFamily: 'var(--font-body)',
                     fontWeight: 400,
                   }}
                 >
-                  {views.toLocaleString()}
+                  {views.toLocaleString()} <span className="sr-only">views</span>
                 </span>
               </div>
-              <div className="flex items-center gap-1">
-                <Heart className="h-3 w-3 text-slate-400 light:text-slate-600" />
+              <div className="flex items-center gap-1" aria-label={`${likes.toLocaleString()} likes`}>
+                <Heart className="h-3 w-3" aria-hidden="true" />
                 <span
                   style={{
                     fontFamily: 'var(--font-body)',
                     fontWeight: 400,
                   }}
                 >
-                  {likes.toLocaleString()}
+                  {likes.toLocaleString()} <span className="sr-only">likes</span>
                 </span>
               </div>
             </div>
@@ -156,15 +184,16 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
           <div className="pt-2">
             <Link
               to={`/blogs/${blog.slug}`}
-              className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60 px-4 py-2 text-sm transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-300/70 hover:bg-slate-900/90 light:hover:bg-white/90 hover:shadow-md hover:shadow-slate-900/50 light:hover:shadow-slate-100/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 text-slate-300 light:text-slate-800"
+              tabIndex={-1}
+              aria-hidden="true"
+              className="inline-flex items-center gap-1 text-sm text-slate-400 light:text-slate-500 transition-colors group-hover:text-slate-200 light:group-hover:text-slate-800"
               style={{
                 fontFamily: 'var(--font-body)',
-                fontWeight: 600,
+                fontWeight: 500,
               }}
-              aria-label={`Read ${blog.title}`}
             >
               Read more
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5 text-slate-300 light:text-slate-800" />
+              <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
             </Link>
           </div>
         </div>

--- a/src/components/homepage/PortfolioCard.tsx
+++ b/src/components/homepage/PortfolioCard.tsx
@@ -1,10 +1,10 @@
+import { useState } from "react";
 import { ArrowRight, ExternalLink, Github } from "lucide-react";
 import { Link } from "react-router";
 import { Card, CardHeader } from "@/components/ui/card";
 import { getTechIcon } from "@/lib/techIcons";
 import type { PortfolioItem } from "@/data/portfolio";
 import { cn } from "@/lib";
-import FadeInUp from "@/components/common/FadeInUp";
 
 interface PortfolioCardProps {
   item: PortfolioItem;
@@ -12,12 +12,20 @@ interface PortfolioCardProps {
 }
 
 export default function PortfolioCard({ item, index }: PortfolioCardProps) {
+  const [imgError, setImgError] = useState(false);
+  const animationDelay = `${80 + index * 70}ms`;
+
   return (
-    <FadeInUp delay={0.12 + index * 0.1}>
       <Card
+        role="article"
+        aria-label={item.title}
         className={cn(
-          "group border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 overflow-hidden flex flex-col h-full"
+          "group border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white transition-all duration-200 hover:border-slate-600/80 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-lg hover:shadow-slate-900/20 light:hover:shadow-slate-300/30 overflow-hidden flex flex-col h-full"
         )}
+        style={{
+          animation: "fade-in-up 500ms ease-out both",
+          animationDelay,
+        }}
       >
         <div className="flex flex-col sm:flex-row flex-1">
           <div className="flex-1 p-3 sm:p-4 md:p-5 space-y-2 flex flex-col">
@@ -42,18 +50,30 @@ export default function PortfolioCard({ item, index }: PortfolioCardProps) {
               </p>
             </CardHeader>
           </div>
-          <div className="relative w-full sm:w-48 md:w-56 lg:w-64 flex-shrink-0 h-40">
-            <img
-              src={item.image}
-              alt={item.title}
-              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-              loading="lazy"
-              decoding="async"
-            />
+          <div className="relative w-full sm:w-48 md:w-56 lg:w-64 flex-shrink-0 h-40 overflow-hidden bg-slate-800/40 light:bg-slate-100/60">
+            {imgError ? (
+              <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
+                <span
+                  className="text-center text-xs text-slate-400 light:text-slate-500 line-clamp-3"
+                  style={{ fontFamily: "var(--font-body)", fontWeight: 500 }}
+                >
+                  {item.title}
+                </span>
+              </div>
+            ) : (
+              <img
+                src={item.image}
+                alt={item.title}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                loading="lazy"
+                decoding="async"
+                onError={() => setImgError(true)}
+              />
+            )}
           </div>
         </div>
         <div className="border-t border-slate-800/70 light:border-slate-300 p-3 sm:p-4 md:p-4 space-y-2 sm:space-y-3 flex flex-col flex-1">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2" aria-label="Technologies used" role="list">
             {item.techStack.slice(0, 5).map((tech) => {
               const Icon = getTechIcon(tech);
               if (!Icon) return null;
@@ -62,8 +82,9 @@ export default function PortfolioCard({ item, index }: PortfolioCardProps) {
                   key={tech}
                   className="flex items-center gap-1 sm:gap-1.5 rounded border border-slate-800/70 light:border-slate-300 bg-slate-900/80 light:bg-slate-50 px-2 py-1 text-xs"
                   title={tech}
+                  role="listitem"
                 >
-                  <Icon className="h-3 sm:h-3.5 w-3 sm:w-3.5 text-slate-400 light:text-slate-600" />
+                  <Icon className="h-3 sm:h-3.5 w-3 sm:w-3.5 text-slate-400 light:text-slate-600" aria-hidden="true" />
                   <span
                     className="hidden sm:inline text-slate-400 light:text-slate-600"
                     style={{
@@ -135,6 +156,5 @@ export default function PortfolioCard({ item, index }: PortfolioCardProps) {
           </div>
         </div>
       </Card>
-    </FadeInUp>
   );
 }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -83,27 +83,31 @@ PaginationItem.displayName =
 type PaginationLinkProps =
   {
     isActive?: boolean;
+    disabled?: boolean;
   } & Pick<
     ButtonProps,
     "size"
   > &
-    React.ComponentProps<"a">;
+    React.ComponentProps<"button">;
 
 const PaginationLink =
   ({
     className,
     isActive,
+    disabled,
     size = "icon",
     ...props
   }: PaginationLinkProps) => (
-    <a
+    <button
+      type="button"
       aria-current={
         isActive
           ? "page"
           : undefined
       }
+      disabled={disabled}
       className={cn(
-        "group relative inline-flex items-center justify-center rounded-full border backdrop-blur-xl transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-100/60 focus-visible:ring-offset-slate-900 light:focus-visible:ring-slate-900/40 light:focus-visible:ring-offset-white shadow-[0_15px_45px_rgba(2,6,23,0.35)] light:shadow-[0_12px_35px_rgba(15,23,42,0.08)] text-sm font-medium",
+        "group relative inline-flex items-center justify-center rounded-full border backdrop-blur-xl transition-all duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-100/60 focus-visible:ring-offset-slate-900 light:focus-visible:ring-slate-900/40 light:focus-visible:ring-offset-white shadow-[0_15px_45px_rgba(2,6,23,0.35)] light:shadow-[0_12px_35px_rgba(15,23,42,0.08)] text-sm font-medium",
         size ===
           "icon"
           ? "h-10 w-10"
@@ -111,6 +115,8 @@ const PaginationLink =
         "border-slate-800/70 bg-slate-900/65 text-slate-200/90 hover:text-white hover:border-slate-700/60 hover:bg-slate-900/90 light:border-slate-200/60 light:bg-white/80 light:text-slate-700 light:hover:text-slate-900 light:hover:border-slate-300/70",
         isActive &&
           "text-slate-900 light:text-white bg-gradient-to-br from-slate-100 via-slate-200 to-white light:from-slate-900 light:via-slate-800 light:to-slate-700 border-transparent shadow-[0_25px_50px_rgba(2,6,23,0.55)] light:shadow-[0_18px_40px_rgba(15,23,42,0.25)]",
+        disabled &&
+          "opacity-50 cursor-not-allowed",
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -1478,6 +1478,16 @@ Option 5: Noise Texture Pattern (Subtle)
     ease-out;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* Animated gradient orbs for Experiences section */
 @keyframes float-orb-1 {
   0%,

--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -66,11 +66,11 @@ export default function Blogs() {
         <div
           className="px-6 md:px-0 flex flex-col items-center gap-4 mb-12"
           style={{
-            animation: "fade-in 900ms ease-out both",
+            animation: "fade-in 400ms ease-out both",
             animationDelay: "60ms",
           }}
         >
-          <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-300/60 bg-slate-900/60 light:bg-slate-100/60">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-300/60 bg-slate-900/60 light:bg-slate-100/60" aria-hidden="true">
             <BookOpen className="h-6 w-6 text-slate-300 light:text-slate-700" />
           </div>
           <h1
@@ -94,13 +94,20 @@ export default function Blogs() {
           </p>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-2 mb-8">
+        <div
+          className="flex flex-wrap items-center justify-center gap-2 mb-8"
+          role="tablist"
+          aria-label="Filter blog posts by category"
+        >
           {categories.map((category) => (
             <button
               key={category}
+              role="tab"
+              aria-selected={selectedCategory === category}
+              aria-controls="blog-feed"
               onClick={() => setSelectedCategory(category)}
               className={cn(
-                "px-4 py-2 rounded-md border text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40",
+                "px-4 py-2 rounded-md border text-sm cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40",
                 selectedCategory === category
                   ? "border-slate-700/70 light:border-slate-200/70 bg-slate-900/90 light:bg-white/90 text-slate-200 light:text-slate-800"
                   : "border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 hover:border-slate-700/70 light:hover:border-slate-200/70 hover:bg-slate-900/80 light:hover:bg-slate-100/80 text-slate-400 light:text-slate-600"
@@ -109,14 +116,19 @@ export default function Blogs() {
                 fontFamily: "var(--font-body)",
                 fontWeight: selectedCategory === category ? 600 : 500,
               }}
-              aria-label={`Filter by ${category}`}
             >
               {category}
             </button>
           ))}
         </div>
 
-        <div className="space-y-4">
+        <div className="sr-only" aria-live="polite" role="status">
+          {filteredBlogs.length === 0
+            ? "No blog posts found"
+            : `${filteredBlogs.length} blog post${filteredBlogs.length === 1 ? "" : "s"} found`}
+        </div>
+
+        <div id="blog-feed" role="feed" aria-label="Blog posts" className="space-y-6">
           {paginatedBlogs.length === 0 ? (
             <div className="text-center py-12">
               <p
@@ -150,11 +162,8 @@ export default function Blogs() {
                   <PaginationItem>
                     <PaginationPrevious
                       onClick={() => handlePageChange(currentPage - 1)}
-                      className={cn(
-                        "px-5",
-                        currentPage === 1 && "pointer-events-none opacity-50"
-                      )}
-                      aria-disabled={currentPage === 1}
+                      disabled={currentPage === 1}
+                      className="px-5"
                     />
                   </PaginationItem>
 
@@ -196,12 +205,8 @@ export default function Blogs() {
                   <PaginationItem>
                     <PaginationNext
                       onClick={() => handlePageChange(currentPage + 1)}
-                      className={cn(
-                        "px-5",
-                        currentPage === totalPages &&
-                          "pointer-events-none opacity-50"
-                      )}
-                      aria-disabled={currentPage === totalPages}
+                      disabled={currentPage === totalPages}
+                      className="px-5"
                     />
                   </PaginationItem>
                 </PaginationContent>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -486,13 +486,13 @@ export default function Projects() {
           </div>
         </FadeInUp>
 
-        <FadeInUp delay={0.12}>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 auto-rows-fr">
-            {portfolioItems.map((item, index) => (
-              <PortfolioCard key={item.id} item={item} index={index} />
-            ))}
-          </div>
-        </FadeInUp>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 auto-rows-fr" role="list" aria-label="Project list">
+          {portfolioItems.map((item, index) => (
+            <div key={item.id} role="listitem">
+              <PortfolioCard item={item} index={index} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #9

- **Broken image fallback**: Both BlogCard and PortfolioCard now detect `onError` on `<img>` and swap to a gray placeholder showing the title text
- **Accessibility**: Added `role="article"`, `aria-label`, `role="list"`/`role="listitem"` semantics to card grids, tech stacks, and pagination. Decorative icons marked `aria-hidden="true"`
- **Animation**: PortfolioCard now uses CSS stagger animation (`fade-in-up` 500ms, delay 80+index*70ms) instead of heavy FadeInUp wrapper. Blog animations sped up (400ms)
- **UX**: Category filter buttons get `cursor-pointer`, cards get hover shadow depth, enhanced border glow on hover

## Test plan

- [ ] Visit `/blogs` — verify broken blog images show gray fallback with title
- [ ] Visit `/projects` — verify broken project images show gray fallback with title  
- [ ] Check stagger animation on both pages (cards appear sequentially)
- [ ] Hover over project cards — shadow + border glow visible
- [ ] Tab through cards — focus rings visible on all interactive elements
- [ ] Test with screen reader — cards, tech stacks, pagination are announced correctly
- [ ] Verify both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)