### PR TITLE
fix: accordion stretch & project detail cleanup

### DIFF
--- a/src/components/homepage/ExperienceCard.tsx
+++ b/src/components/homepage/ExperienceCard.tsx
@@ -41,11 +41,11 @@ export default function ExperienceCard({
         index *
           0.1
       }
-      className="h-full"
+      className=""
     >
       <article
         className={cn(
-          "flex h-full flex-col rounded-lg border border-slate-800/70 light:border-slate-200 bg-slate-900/60 light:bg-white p-2.5 sm:p-3 motion-safe:transition-all motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-lg hover:shadow-slate-900/50 light:hover:shadow-slate-200",
+          "flex flex-col rounded-lg border border-slate-800/70 light:border-slate-200 bg-slate-900/60 light:bg-white p-2.5 sm:p-3 motion-safe:transition-all motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-lg hover:shadow-slate-900/50 light:hover:shadow-slate-200",
           isCurrent &&
             "border-slate-700/50 light:border-slate-300 ring-1 ring-slate-700/20 light:ring-slate-300/20",
         )}

--- a/src/components/homepage/ExperienceSection.tsx
+++ b/src/components/homepage/ExperienceSection.tsx
@@ -51,7 +51,7 @@ export default function ExperienceSection() {
               0.12
             }
           >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 auto-rows-[1fr]">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 items-start">
               {latestExperiences.map(
                 (
                   experience,

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useParams, Link } from "react-router";
 import { ArrowLeft, ExternalLink, Github } from "lucide-react";
 import { getProjectBySlug } from "@/data/portfolio";
@@ -6,12 +7,15 @@ import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import TableOfContents from "@/components/projects/TableOfContents";
 import { getTechIcon } from "@/lib/techIcons";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function ProjectDetail() {
   const { slug } = useParams<{
     slug: string;
   }>();
   const project = slug ? getProjectBySlug(slug) : undefined;
+  const [imgError, setImgError] = useState(false);
+  const [imgLoading, setImgLoading] = useState(true);
 
   if (!project || !project.content) {
     return (
@@ -35,7 +39,7 @@ export default function ProjectDetail() {
 
   return (
     <div className="project-detail-pattern min-h-screen flex flex-col relative bg-slate-950 light:bg-slate-50">
-      <div className="mx-auto max-w-7xl sm:px-6 w-full px-6 md:px-0 py-12 md:py-16 relative z-10">
+      <div className="mx-auto max-w-6xl sm:px-6 w-full px-6 md:px-0 py-12 md:py-16 relative z-10">
         <Link
           to="/projects"
           className="inline-flex items-center gap-2 mb-8 text-slate-400 light:text-slate-600 hover:text-slate-200 light:hover:text-slate-800 transition-colors font-body font-medium"
@@ -47,102 +51,116 @@ export default function ProjectDetail() {
         <div className="flex flex-col lg:flex-row gap-8">
           <div className="flex-1 min-w-0">
             <article
-              className="space-y-6 bg-slate-900/30 light:bg-white/40 rounded-lg p-6 md:p-8 border border-slate-800/50 light:border-slate-200/50"
               style={{
                 animation: "fade-in 900ms ease-out both",
                 animationDelay: "60ms",
               }}
             >
-              <header className="space-y-4">
-                {project.image && (
-                  <div className="relative w-full h-64 md:h-80 lg:h-96 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60">
-                    <img
-                      src={project.image}
-                      alt={project.title}
-                      className="w-full h-full object-cover"
-                      loading="eager"
-                      decoding="async"
-                    />
-                  </div>
+              {/* Header */}
+              <header className="mb-8 max-w-prose mx-auto">
+                {project.type === "blog" && (
+                  <Badge
+                    variant="outline"
+                    className="mb-3 border-slate-700/70 light:border-slate-300/70 text-slate-400 light:text-slate-600 bg-slate-900/40 light:bg-slate-100/40 font-body"
+                  >
+                    Technical Blog
+                  </Badge>
                 )}
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <h1 className="text-3xl md:text-4xl text-slate-100 light:text-slate-900 mb-2 font-mono font-bold">
-                      {project.title}
-                    </h1>
-                    <p className="text-base md:text-lg mb-4 font-blog font-normal leading-[1.75] text-slate-300 light:text-slate-700">
-                      {project.description}
-                    </p>
-                  </div>
-                  {project.type === "blog" && (
-                    <Badge
-                      variant="outline"
-                      className="border-slate-700/70 light:border-slate-300/70 text-slate-300 light:text-slate-600 bg-slate-900/40 light:bg-slate-100/40 font-body font-medium"
-                    >
-                      Technical Blog
-                    </Badge>
-                  )}
-                </div>
 
-                <div className="flex flex-wrap items-center gap-2">
-                  {project.techStack.slice(0, 5).map((tech) => {
-                    const Icon = getTechIcon(tech);
-                    return (
+                <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold leading-tight mb-3 text-slate-100 light:text-slate-900 font-blog">
+                  {project.title}
+                </h1>
+
+                <p className="text-sm md:text-base leading-relaxed mb-5 text-slate-400 light:text-slate-600 font-blog max-w-prose">
+                  {project.description}
+                </p>
+
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-5 border-b border-slate-800/50 light:border-slate-200/50">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {project.techStack.slice(0, 5).map((tech) => {
+                      const Icon = getTechIcon(tech);
+                      return (
+                        <div
+                          key={tech}
+                          className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1"
+                          title={tech}
+                        >
+                          {Icon && (
+                            <Icon className="h-3.5 w-3.5 text-slate-400 light:text-slate-600" />
+                          )}
+                          <span className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium">
+                            {tech}
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {project.techStack.length > 5 && (
                       <div
-                        key={tech}
-                        className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1"
-                        title={tech}
+                        className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1 font-semibold"
+                        title={project.techStack.slice(5).join(", ")}
                       >
-                        {Icon && (
-                          <Icon className="h-3.5 w-3.5 text-slate-400 light:text-slate-600" />
-                        )}
                         <span className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium">
-                          {tech}
+                          +{project.techStack.length - 5}
                         </span>
                       </div>
-                    );
-                  })}
-                  {project.techStack.length > 5 && (
-                    <div
-                      className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1 font-semibold"
-                      title={project.techStack.slice(5).join(", ")}
-                    >
-                      <span className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium">
-                        +{project.techStack.length - 5}
-                      </span>
-                    </div>
-                  )}
-                </div>
+                    )}
+                  </div>
 
-                <div className="flex flex-wrap items-center gap-3 pt-2">
-                  {project.liveUrl && (
-                    <a
-                      href={project.liveUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                      aria-label={`Visit ${project.title} live website`}
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                      Live Demo
-                    </a>
-                  )}
-                  {project.githubUrl && (
-                    <a
-                      href={project.githubUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                      aria-label={`View ${project.title} on GitHub`}
-                    >
-                      <Github className="h-4 w-4" />
-                      View Code
-                    </a>
-                  )}
+                  <div className="flex flex-wrap items-center gap-3">
+                    {project.liveUrl && (
+                      <a
+                        href={project.liveUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
+                        aria-label={`Visit ${project.title} live website`}
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                        Live Demo
+                      </a>
+                    )}
+                    {project.githubUrl && (
+                      <a
+                        href={project.githubUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
+                        aria-label={`View ${project.title} on GitHub`}
+                      >
+                        <Github className="h-4 w-4" />
+                        View Code
+                      </a>
+                    )}
+                  </div>
                 </div>
               </header>
 
-              <div className="prose prose-invert max-w-none">
+              {/* Hero image with fallback */}
+              <div className="relative w-full h-64 md:h-80 lg:h-96 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60 mb-8">
+                {imgLoading && !imgError && project.image && (
+                  <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-slate-800/60" />
+                )}
+                {!project.image || imgError ? (
+                  <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
+                    <span className="text-center text-sm text-slate-400 light:text-slate-500 font-body font-medium">
+                      {project.title}
+                    </span>
+                  </div>
+                ) : (
+                  <img
+                    src={project.image}
+                    alt={project.title}
+                    className="w-full h-full object-cover"
+                    loading="eager"
+                    decoding="async"
+                    onLoad={() => setImgLoading(false)}
+                    onError={() => setImgError(true)}
+                  />
+                )}
+              </div>
+
+              {/* Content */}
+              <div className="max-w-prose mx-auto">
                 <MarkdownRenderer content={project.content} />
               </div>
             </article>


### PR DESCRIPTION
## Summary
- **Experience accordion fix**: Remove `auto-rows-[1fr]` and `h-full` from the homepage experience grid so expanding an accordion only affects the clicked card, not siblings in the same row
- **Project detail page**: Restructure layout to match BlogDetail format — removed card wrapper, added `max-w-prose` content constraints, proper header with border separator
- **Fallback image**: Added loading skeleton and error fallback for broken/missing project hero images (same pattern as PortfolioCard)

## Test plan
- [ ] Open homepage, click "Key Achievements" accordion on any experience card — sibling card should NOT stretch
- [ ] Navigate to a project detail page — layout should match blog detail format
- [ ] Verify broken image URLs show fallback text instead of raw alt text
- [ ] Check both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)