### PR TITLE
update mentor and speaker

### DIFF
--- a/src/components/homepage/MentorSpeakerSection.tsx
+++ b/src/components/homepage/MentorSpeakerSection.tsx
@@ -1,10 +1,12 @@
 import { ArrowRight } from 'lucide-react'
 import { Link } from 'react-router'
-import { mentorSpeakerEngagements } from '@/data/mentorSpeaker'
+import { getHomeMentorSpeakerPreview } from '@/data/mentorSpeaker'
 import MentorSpeakerItem from './MentorSpeakerItem'
 import FadeInUp from '@/components/common/FadeInUp'
 
 export default function MentorSpeakerSection() {
+  const previewItems = getHomeMentorSpeakerPreview()
+
   return (
     <section id="mentor-speaker" aria-labelledby="mentor-speaker-heading" className="relative bg-slate-950 light:bg-slate-50 px-6 md:px-0 py-12 md:py-16">
       <div className="mx-auto max-w-7xl sm:px-6 w-full">
@@ -19,13 +21,13 @@ export default function MentorSpeakerSection() {
           </FadeInUp>
           <FadeInUp delay={0.12}>
             <div className="flex flex-col">
-              {mentorSpeakerEngagements.slice(0, 4).map((item, index) => (
+              {previewItems.map((item, index) => (
                 <MentorSpeakerItem key={item.id} item={item} index={index} />
               ))}
             </div>
           </FadeInUp>
 
-          <FadeInUp delay={0.12 + mentorSpeakerEngagements.slice(0, 4).length * 0.1}>
+          <FadeInUp delay={0.12 + previewItems.length * 0.1}>
             <div className="flex justify-center pt-4">
             <Link
               to="/speaker"

--- a/src/data/mentorSpeaker.ts
+++ b/src/data/mentorSpeaker.ts
@@ -17,6 +17,23 @@ export interface MentorSpeakerItem {
 
 export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
+    id: '13',
+    eventName: 'Agentic AI for Builders: From Prompt to Autonomous Coding Loop',
+    brief: 'Meetup on how autonomous coding agents run through structured cycles: Plan, Act, Verify, and Iterate. Covered decomposing tasks, multi-step execution, evaluating intermediate outputs, and self-correction toward a defined goal—treating AI as a workflow, not a single-shot generator.',
+    date: '19 February 2026',
+    type: 'speaker',
+  },
+  {
+    id: '14',
+    eventName: '101 Vibe Engineering with MiniMax M2.1',
+    brief: 'Session introducing vibe engineering practices with MiniMax M2.1.',
+    date: 'January 2026',
+    type: 'speaker',
+    links: {
+      website: 'https://luma.com/7bbx8bo9',
+    },
+  },
+  {
     id: '1',
     eventName: 'Basic Javascript with Weather Apps',
     brief: 'Build simple website using HTML/CSS/JS for swifting career to Frontend.',
@@ -63,7 +80,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
     date: 'Ongoing',
     type: 'speaker',
     links: {
-      x: 'https://twitter.com/f2aldi',
+      x: 'https://x.com/f2aldi',
     },
   },
   {
@@ -141,7 +158,60 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
       linkedin: 'https://www.linkedin.com/in/naufaldirafif/',
     },
   },
+  {
+    id: '15',
+    eventName: 'MOFON (Mentorship Frontend)',
+    brief: 'Frontend Developer Mentor: HTML, CSS, and JavaScript fundamentals, personalized feedback, curriculum design, and collaboration with other mentors to improve the learning experience for students at all levels.',
+    date: 'December 2020 – November 2024',
+    type: 'mentoring',
+    links: {
+      website: 'https://mofon.vercel.app',
+      linkedin: 'https://www.linkedin.com/in/naufaldirafif/',
+    },
+  },
+  {
+    id: '16',
+    eventName: 'Esteh Creative',
+    brief: 'Mentor Frontend Developer: fundamentals of web development, recorded tutorials, and hands-on guidance alongside teaching core HTML, CSS, and JavaScript practices.',
+    date: 'March 2021 – December 2023',
+    type: 'mentoring',
+    links: {
+      website: 'https://www.esteh.id',
+      linkedin: 'https://www.linkedin.com/in/naufaldirafif/',
+    },
+  },
+  {
+    id: '17',
+    eventName: 'Nest Academy',
+    brief: 'Frontend Engineer Mentor: built and delivered a structured HTML, CSS, and JavaScript curriculum, guided learners through projects with best practices, and provided ongoing technical support.',
+    date: 'August 2022 – September 2022',
+    type: 'mentoring',
+    links: {
+      website: 'https://nestacademy.id',
+      linkedin: 'https://www.linkedin.com/in/naufaldirafif/',
+    },
+  },
+  {
+    id: '18',
+    eventName: 'Fast Campus — All-in-One Frontend Web Development',
+    brief: 'Course instructor for the All-in-One Frontend Web Development package (From Zero To Hero), alongside Jessica Cecilia B., F. Dhani Achmad, and Rizky Ramadhan.',
+    date: 'Ongoing',
+    type: 'mentoring',
+    links: {
+      website: 'https://fastcampus.com/en/products/dev_online_fe',
+      linkedin: 'https://www.linkedin.com/in/naufaldirafif/',
+    },
+  },
 ]
+
+const HOME_MENTOR_SPEAKER_FEATURED_IDS = ['13', '14', '5', '6'] as const
+
+export const getHomeMentorSpeakerPreview = (): MentorSpeakerItem[] => {
+  const byId = new Map(mentorSpeakerEngagements.map((item) => [item.id, item]))
+  return HOME_MENTOR_SPEAKER_FEATURED_IDS.map((id) => byId.get(id)).filter(
+    (item): item is MentorSpeakerItem => item !== undefined,
+  )
+}
 
 export const getMentoringEngagements = (): MentorSpeakerItem[] => {
   return mentorSpeakerEngagements.filter((item) => item.type === 'mentoring')

--- a/src/data/speaker.ts
+++ b/src/data/speaker.ts
@@ -15,7 +15,7 @@ export interface OrganizationLogo {
 export const speakerMentorStats: SpeakerMentorStats = {
   menteesTaught: 1000,
   mentoringSessions: 150,
-  speakingEngagements: 25,
+  speakingEngagements: 27,
   speakerTime: '100+ hours',
 }
 
@@ -31,6 +31,19 @@ export const organizationLogos: OrganizationLogo[] = [
     logoUrl: 'https://res.cloudinary.com/cynux/image/upload/v1762849014/portfolio-2025/logo/nest.jpg',
     type: 'mentoring',
     websiteUrl: 'https://nestacademy.id',
+  },
+  {
+    name: 'MOFON',
+    logoUrl: 'https://avatars.githubusercontent.com/naufaldi?s=128',
+    type: 'mentoring',
+    websiteUrl: 'https://mofon.vercel.app',
+  },
+  {
+    name: 'Esteh Creative',
+    logoUrl:
+      'https://t0.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://esteh.id&size=128',
+    type: 'mentoring',
+    websiteUrl: 'https://www.esteh.id',
   },
   {
     name: 'Dibimbing',
@@ -54,7 +67,7 @@ export const organizationLogos: OrganizationLogo[] = [
     name: 'Fast Campus',
     logoUrl: 'https://res.cloudinary.com/cynux/image/upload/v1762851008/portfolio-2025/logo/fast-campus.jpg',
     type: 'mentoring',
-    websiteUrl: 'https://fastcampus.com/',
+    websiteUrl: 'https://fastcampus.com/en/products/dev_online_fe',
   },
   {
     name: 'Ekskul',


### PR DESCRIPTION
## Related
Closes #34

## Changes
- `mentorSpeaker.ts`: new mentoring rows (MOFON, Esteh, Nest Academy, Fast Campus), `getHomeMentorSpeakerPreview`, 2026 speaker entries, Luma + x.com links
- `speaker.ts`: MOFON/Esteh marquee entries, Fast Campus product URL, speaking count
- `MentorSpeakerSection.tsx`: use featured preview helper

## Verification
- `bun run tsc --noEmit`
- `bun run build`

Made with [Cursor](https://cursor.com)