### PR TITLE
feat: redesign homepage editorial system

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router'
-import { Twitter, Linkedin, Mail, Github, Instagram } from 'lucide-react'
+import { Github, Instagram, Linkedin, Mail, Twitter } from 'lucide-react'
 import { siteConfig } from '@/data/site'
+import FooterColumn from '@/components/design-system/FooterColumn'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
 import { cn } from '@/lib'
 
 const generalLinks = [
@@ -28,77 +30,64 @@ const resourceLinks = [
 ]
 
 const socialIcons = [
-  {
-    name: 'Email',
-    icon: Mail,
-    href: siteConfig.socialLinks.email || '#',
-    ariaLabel: 'Send email to Naufaldi Rafif S.',
-  },
-  {
-    name: 'LinkedIn',
-    icon: Linkedin,
-    href: siteConfig.socialLinks.linkedin || '#',
-    ariaLabel: 'Visit LinkedIn profile',
-  },
-  {
-    name: 'Twitter/X',
-    icon: Twitter,
-    href: siteConfig.socialLinks.twitter || '#',
-    ariaLabel: 'Follow on X (Twitter)',
-  },
-  {
-    name: 'GitHub',
-    icon: Github,
-    href: siteConfig.socialLinks.github || '#',
-    ariaLabel: 'Visit GitHub profile',
-  },
-  {
-    name: 'Instagram',
-    icon: Instagram,
-    href: siteConfig.socialLinks.instagram || '#',
-    ariaLabel: 'Follow on Instagram',
-  },
+  { name: 'Email', icon: Mail, href: siteConfig.socialLinks.email || '#', ariaLabel: 'Send email to Naufaldi Rafif S.' },
+  { name: 'LinkedIn', icon: Linkedin, href: siteConfig.socialLinks.linkedin || '#', ariaLabel: 'Visit LinkedIn profile' },
+  { name: 'Twitter/X', icon: Twitter, href: siteConfig.socialLinks.twitter || '#', ariaLabel: 'Follow on X' },
+  { name: 'GitHub', icon: Github, href: siteConfig.socialLinks.github || '#', ariaLabel: 'Visit GitHub profile' },
+  { name: 'Instagram', icon: Instagram, href: siteConfig.socialLinks.instagram || '#', ariaLabel: 'Follow on Instagram' },
 ]
 
-const renderLink = (link: { name: string; href: string; external: boolean }) => {
-  const linkClassName = cn(
-    'text-sm text-slate-300 light:text-slate-700 hover:text-slate-100 light:hover:text-slate-900 transition-colors duration-200',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black light:focus-visible:ring-offset-white',
-    'underline-offset-4 hover:underline'
-  )
+const footerLinkClassName =
+  'font-mono text-xs uppercase tracking-[0.08em] text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]'
 
+const renderLink = (link: { name: string; href: string; external: boolean }) => {
   if (link.external) {
     return (
-      <a
-        key={link.name}
-        href={link.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={linkClassName}
-      >
+      <a key={link.name} href={link.href} target="_blank" rel="noopener noreferrer" className={footerLinkClassName}>
         {link.name}
       </a>
     )
   }
 
   return (
-    <Link key={link.name} to={link.href} className={linkClassName}>
+    <Link key={link.name} to={link.href} className={footerLinkClassName}>
       {link.name}
     </Link>
   )
 }
 
 export default function Footer() {
+  const footerSignals = [
+    { label: 'BUILD', value: '2026' },
+    { label: 'SYSTEM', value: 'faldi.xyz' },
+    { label: 'OWNER', value: siteConfig.name },
+  ]
+
   return (
-    <footer className="bg-black light:bg-white border-t border-slate-800 light:border-slate-300">
-      <div className="max-w-7xl mx-auto px-6 md:px-0 py-12 md:py-16">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-6">
-          <div className="lg:col-span-1 space-y-4">
-            <h2 className="text-xl font-bold text-white light:text-slate-900">{siteConfig.name}</h2>
-            <p className="text-sm text-slate-400 light:text-slate-600 leading-relaxed">
-              {siteConfig.tagline}
-            </p>
-            <div className="flex items-center gap-4">
+    <footer className="bg-[var(--paper)] py-12 md:py-16">
+      <div className="site-container">
+        <div className="grid gap-px border-y border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-3">
+          {footerSignals.map((signal, index) => (
+            <div key={signal.label} className="bg-[var(--paper)] px-4 py-4 md:px-5">
+              <div className="text-drawing-label">
+                {String(index + 1).padStart(2, '0')} // {signal.label}
+              </div>
+              <p className="mt-3 font-mono text-sm uppercase tracking-[0.12em] text-[var(--graphite)]">
+                {signal.value}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-px border-b border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-5">
+            <div className="bg-[var(--paper)] px-4 py-8 md:px-5 md:py-10">
+              <div className="text-drawing-label">01 // IDENTITY</div>
+              <div className="mt-5">
+              <h2 className="font-mono text-2xl font-medium text-[var(--graphite)]">{siteConfig.name}</h2>
+              <p className="mt-2 text-sm text-[var(--graphite-muted)]">{siteConfig.tagline}</p>
+            </div>
+              <div className="mt-6 flex items-center gap-3">
               {socialIcons.map((social) => {
                 const Icon = social.icon
                 return (
@@ -108,52 +97,35 @@ export default function Footer() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className={cn(
-                      'inline-flex items-center justify-center w-10 h-10 rounded-md',
-                      'text-slate-300 light:text-slate-700 hover:text-slate-200 light:hover:text-slate-900 transition-colors duration-200',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
-                      'focus-visible:ring-offset-2 focus-visible:ring-offset-black light:focus-visible:ring-offset-white'
+                      'inline-flex h-9 w-9 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--border-line)] text-[var(--graphite-muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]',
                     )}
                     aria-label={social.ariaLabel}
                   >
-                    <Icon className="w-5 h-5" aria-hidden="true" />
+                    <Icon className="h-4 w-4" aria-hidden="true" />
                   </a>
                 )
               })}
+              </div>
             </div>
           </div>
 
-          <nav className="space-y-4" aria-label="General navigation">
-            <h3 className="text-sm font-semibold text-slate-400 light:text-slate-600 uppercase tracking-wider">
-              General
-            </h3>
-            <ul className="flex flex-col space-y-3">
-              {generalLinks.map(renderLink)}
-            </ul>
-          </nav>
-
-          <nav className="space-y-4" aria-label="Website navigation">
-            <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">
-              The Website
-            </h3>
-            <ul className="flex flex-col space-y-3">
-              {websiteLinks.map(renderLink)}
-            </ul>
-          </nav>
-
-          <nav className="space-y-4" aria-label="Resources">
-            <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">
-              Resources
-            </h3>
-            <ul className="flex flex-col space-y-3">
-              {resourceLinks.map(renderLink)}
-            </ul>
-          </nav>
+          <FooterColumn title="GENERAL" className="bg-[var(--paper)] px-4 py-8 md:px-5 md:py-10">
+            {generalLinks.map(renderLink)}
+          </FooterColumn>
+          <FooterColumn title="THE WEBSITE" className="bg-[var(--paper)] px-4 py-8 md:px-5 md:py-10">
+            {websiteLinks.map(renderLink)}
+          </FooterColumn>
+          <FooterColumn title="RESOURCES" className="bg-[var(--paper)] px-4 py-8 md:px-5 md:py-10">
+            {resourceLinks.map(renderLink)}
+          </FooterColumn>
         </div>
 
-        <div className="border-t border-slate-800 light:border-slate-300 mt-12 pt-8">
-          <p className="text-sm text-slate-500 light:text-slate-600 text-center">
-            Copyright © 2025 {siteConfig.name}. All rights reserved.
-          </p>
+        <div className="flex flex-col gap-3 border-b border-[var(--border-line)] py-5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--graphite-muted)] md:flex-row md:items-center md:justify-between">
+          <p>Copyright © 2025 {siteConfig.name}. All rights reserved.</p>
+          <div className="flex flex-wrap gap-3">
+            <TechnicalLabel variant="mono">LOCAL_TIME</TechnicalLabel>
+            <p>Bekasi, Indonesia</p>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,33 +13,32 @@ export default function Header() {
     .toUpperCase();
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 w-full bg-slate-900/95 light:bg-white/95 backdrop-blur-sm border-b border-slate-800/70 light:border-slate-300">
-      <div className="mx-auto max-w-7xl px-6">
-        <div className="flex h-16 items-center justify-between">
+    <header className="fixed top-0 left-0 right-0 z-50 w-full border-b border-[var(--border-line)] bg-[var(--paper)]/94 backdrop-blur-sm">
+      <div className="site-container">
+        <div className="flex h-[72px] items-center justify-between gap-5">
           <Link
             to="/"
             className="inline-flex items-center gap-2 group"
             aria-label="Home"
           >
-            <div className="inline-flex items-center justify-center h-7 w-7 rounded-md border border-slate-800/80 light:border-slate-300 bg-slate-900/80 light:bg-slate-100 ring-1 ring-inset ring-slate-800/40 light:ring-slate-300/40">
-              <span className="text-slate-100 light:text-slate-950 text-[11px] tracking-tight font-medium font-mono">
+            <div className="inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--border-line)] bg-[var(--surface-raised)]">
+              <span className="font-mono text-[11px] font-medium tracking-tight text-[var(--graphite)]">
                 {initials}
               </span>
             </div>
-            <span className="text-slate-300 light:text-slate-800 text-sm tracking-tight font-medium group-hover:text-slate-100 light:group-hover:text-slate-950 transition-colors font-body">
+            <span className="hidden text-sm font-medium tracking-tight text-[var(--graphite)] transition-colors group-hover:text-[var(--graphite-muted)] sm:inline">
               {siteConfig.name}
             </span>
           </Link>
 
-          <div className="flex-1 flex justify-end sm:justify-center">
+          <div className="flex flex-1 justify-end md:justify-center">
             <Navigation />
           </div>
 
-          <div className="hidden md:flex items-center gap-2">
+          <div className="hidden items-center gap-2 md:flex">
             <Button
               asChild
               variant="secondary"
-              className="font-body font-medium"
             >
               <a
                 href="https://www.linkedin.com/in/naufaldirafif/"
@@ -52,7 +51,6 @@ export default function Header() {
             <Button
               asChild
               variant="primary"
-              className="font-body font-semibold"
             >
               <a
                 href="https://www.linkedin.com/in/naufaldirafif/"

--- a/src/components/common/Navigation.tsx
+++ b/src/components/common/Navigation.tsx
@@ -1,493 +1,125 @@
-import { useState } from "react";
-import {
-  useLocation,
-  Link,
-} from "react-router";
-import {
-  Menu,
-  ArrowRight,
-} from "lucide-react";
+import { useState } from 'react'
+import { Link, useLocation } from 'react-router'
+import { Menu } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import {
   NavigationMenu,
+  NavigationMenuContent,
   NavigationMenuItem,
   NavigationMenuList,
   NavigationMenuTrigger,
-  NavigationMenuContent,
-} from "@/components/ui/navigation-menu";
-import { Separator } from "@/components/ui/separator";
+} from '@/components/ui/navigation-menu'
 import {
   Sheet,
   SheetContent,
   SheetTrigger,
-} from "@/components/ui/sheet";
-import { cn } from "@/lib";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { cn } from '@/lib'
 
 interface NavItem {
-  name: string;
-  href: string;
-  external?: boolean;
+  name: string
+  href: string
 }
 
-const navigationItems: NavItem[] =
-  [
-    {
-      name: "Home",
-      href: "/",
-    },
-    {
-      name: "Blog",
-      href: "/blogs",
-    },
-    {
-      name: "Projects",
-      href: "/projects",
-    },
-    {
-      name: "About",
-      href: "/about",
-    },
-    {
-      name: "Speaker",
-      href: "/speaker",
-    },
-  ];
+const navigationItems: NavItem[] = [
+  { name: 'Home', href: '/' },
+  { name: 'Blog', href: '/blogs' },
+  { name: 'Projects', href: '/projects' },
+  { name: 'About', href: '/about' },
+  { name: 'Speaker', href: '/speaker' },
+]
 
-const moreItems: NavItem[] =
-  [
-    {
-      name: "Book",
-      href: "/book",
-    },
-    {
-      name: "Manhwa",
-      href: "/manhwa",
-    },
-    {
-      name: "Short",
-      href: "/shorts",
-    },
-  ];
+const secondaryItems: NavItem[] = [
+  { name: 'Book', href: '/book' },
+  { name: 'Manhwa', href: '/manhwa' },
+  { name: 'Short', href: '/shorts' },
+  { name: 'Experience', href: '/experience' },
+]
 
-// Animation variants for mobile Sheet
-const sheetOverlayVariants = {
-  hidden: {
-    opacity: 0,
-  },
-  visible: {
-    opacity: 1,
-  },
-  exit: {
-    opacity: 0,
-  },
-};
-
-const sheetContentVariants = {
-  hidden: {
-    x: "100%",
-    opacity: 0,
-    scale: 0.95,
-  },
-  visible: {
-    x: 0,
-    opacity: 1,
-    scale: 1,
-  },
-  exit: {
-    x: "100%",
-    opacity: 0,
-    scale: 0.95,
-  },
-};
-
-const sheetItemVariants = {
-  hidden: {
-    x: 50,
-    opacity: 0,
-  },
-  visible: {
-    x: 0,
-    opacity: 1,
-  },
-  exit: {
-    x: 50,
-    opacity: 0,
-  },
-};
+const linkClassName = (isActive: boolean) =>
+  cn(
+    'relative inline-flex h-10 items-center px-1 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-4 focus-visible:ring-offset-[var(--paper)]',
+    isActive &&
+      'text-[var(--graphite)] after:absolute after:bottom-1 after:left-0 after:h-px after:w-full after:bg-[var(--graphite)]',
+  )
 
 export default function Navigation() {
-  const location =
-    useLocation();
-  const currentPath =
-    location.pathname;
-  const [
-    open,
-    setOpen,
-  ] =
-    useState(
-      false,
-    );
-  const prefersReducedMotion = useReducedMotion();
-  const dur = (d: number) => prefersReducedMotion ? 0 : d;
+  const { pathname } = useLocation()
+  const [open, setOpen] = useState(false)
+  const isSecondaryActive = secondaryItems.some((item) => item.href === pathname)
 
   return (
     <>
-      {/* Desktop Navigation */}
-      <div className="hidden md:block">
-        <NavigationMenu
-          delayDuration={
-            200
-          }
-        >
-          <NavigationMenuList className="space-x-0 gap-1 sm:gap-2 flex-wrap">
-            {navigationItems.map(
-              (
-                item,
-              ) => {
-                const isActive =
-                  !item.external &&
-                  currentPath ===
-                    item.href;
-                const linkClassName =
-                  cn(
-                    "inline-flex h-9 sm:h-10 items-center justify-center rounded-full px-3 sm:px-4 py-2 text-xs sm:text-sm font-medium transition-colors duration-200",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                    "disabled:pointer-events-none disabled:opacity-50",
-                    isActive
-                      ? "bg-slate-800/80 light:bg-slate-900 text-slate-100 light:text-white border border-slate-700/60 light:border-slate-800"
-                      : "bg-slate-900/60 light:bg-slate-100 text-slate-300 light:text-slate-700 hover:bg-slate-800/60 light:hover:bg-slate-200 hover:text-blue-400 light:hover:text-slate-900",
-                  );
-
-                return (
-                  <NavigationMenuItem
-                    key={
-                      item.name
-                    }
-                  >
-                    {item.external ? (
-                      <a
-                        href={
-                          item.href
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={
-                          linkClassName
-                        }
-                        style={{
-                          fontFamily:
-                            "var(--font-body)",
-                        }}
-                      >
-                        {
-                          item.name
-                        }
-                      </a>
-                    ) : (
-                      <Link
-                        to={
-                          item.href
-                        }
-                        className={
-                          linkClassName
-                        }
-                        style={{
-                          fontFamily:
-                            "var(--font-body)",
-                        }}
-                      >
-                        {
-                          item.name
-                        }
-                      </Link>
-                    )}
-                  </NavigationMenuItem>
-                );
-              },
-            )}
-            <NavigationMenuItem className="flex items-center">
-              <Separator
-                orientation="vertical"
-                className="h-5 sm:h-6 mx-1 sm:mx-2 bg-slate-700/60 light:bg-slate-300"
-              />
-              <NavigationMenuTrigger
-                className={cn(
-                  "rounded-full bg-slate-900/60 light:bg-slate-100 text-slate-300 light:text-slate-700 hover:bg-slate-800/60 light:hover:bg-slate-200 hover:text-blue-400 light:hover:text-slate-900",
-                  "h-9 sm:h-10 px-3 sm:px-4 py-2 text-xs sm:text-sm font-medium transition-colors duration-200",
-                  "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                  "data-[state=open]:bg-slate-800/80 light:data-[state=open]:bg-slate-900 data-[state=open]:text-slate-100 light:data-[state=open]:text-white",
-                )}
-                style={{
-                  fontFamily:
-                    "var(--font-body)",
-                }}
-              >
-                Other
-              </NavigationMenuTrigger>
-              <NavigationMenuContent className="bg-slate-900/95 light:bg-white backdrop-blur-sm border border-slate-800/70 light:border-slate-300 rounded-lg shadow-lg">
-                <ul className="grid w-[160px] sm:w-[200px] gap-1 p-2">
-                  {moreItems.map(
-                    (
-                      item,
-                    ) => {
-                      const isActive =
-                        currentPath ===
-                        item.href;
-                      return (
-                        <li
-                          key={
-                            item.name
-                          }
-                        >
-                          <Link
-                            to={
-                              item.href
-                            }
-                            className={cn(
-                              "block select-none rounded-md px-3 py-2 text-xs sm:text-sm leading-none no-underline outline-none transition-colors",
-                              "hover:bg-slate-800/60 light:hover:bg-slate-100 hover:text-slate-100 light:hover:text-slate-900 focus:bg-slate-800/60 light:focus:bg-slate-100 focus:text-slate-100 light:focus:text-slate-900",
-                              isActive &&
-                                "bg-slate-800/80 light:bg-slate-900 text-slate-100 light:text-white",
-                              !isActive &&
-                                "text-slate-300 light:text-slate-700",
-                            )}
-                            style={{
-                              fontFamily:
-                                "var(--font-body)",
-                              fontWeight: 500,
-                            }}
-                          >
-                            <div className="font-medium leading-none">
-                              {
-                                item.name
-                              }
-                            </div>
-                          </Link>
-                        </li>
-                      );
-                    },
-                  )}
-                </ul>
-              </NavigationMenuContent>
+      <NavigationMenu className="hidden md:flex" delayDuration={120}>
+        <NavigationMenuList className="flex items-center gap-7">
+          {navigationItems.map((item) => (
+            <NavigationMenuItem key={item.name}>
+              <Link to={item.href} className={linkClassName(pathname === item.href)}>
+                {item.name}
+              </Link>
             </NavigationMenuItem>
-          </NavigationMenuList>
-        </NavigationMenu>
-      </div>
+          ))}
 
-      {/* Mobile Navigation - Hamburger Menu with Sheet Animations */}
-      <div className="md:hidden">
-        <Sheet
-          open={
-            open
-          }
-          onOpenChange={
-            setOpen
-          }
-        >
-          <SheetTrigger asChild>
-            <motion.button
-              className="inline-flex items-center justify-center p-2 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-800/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40"
-              aria-label="Toggle navigation menu"
-              whileHover={prefersReducedMotion ? {} : { scale: 1.05 }}
-              whileTap={prefersReducedMotion ? {} : { scale: 0.95 }}
-              transition={{ duration: dur(0.2) }}
+          <NavigationMenuItem className="relative">
+            <NavigationMenuTrigger
+              className={cn(
+                'relative inline-flex h-10 items-center gap-1 px-1 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-4 focus-visible:ring-offset-[var(--paper)] data-[state=open]:text-[var(--graphite)]',
+                'rounded-none bg-transparent py-0 hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent data-[state=open]:hover:bg-transparent data-[state=open]:focus:bg-transparent',
+                isSecondaryActive &&
+                  'text-[var(--graphite)] after:absolute after:bottom-1 after:left-0 after:h-px after:w-full after:bg-[var(--graphite)]',
+              )}
             >
-              <Menu className="h-6 w-6" />
-            </motion.button>
-          </SheetTrigger>
-          
-          <AnimatePresence>
-            {open && (
-              <>
-                {/* Animated Overlay */}
-                <motion.div
-                  className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-                  variants={sheetOverlayVariants}
-                  initial="hidden"
-                  animate="visible"
-                  exit="exit"
-                  transition={{ duration: dur(0.3) }}
-                />
-
-                {/* Animated Sheet Content */}
-                <SheetContent 
-                  side="right" 
-                  className="w-full flex flex-col p-0 border-l border-slate-800/70"
-                >
-                  <motion.div
-                    className="w-full flex flex-col p-0"
-                    variants={sheetContentVariants}
-                    initial="hidden"
-                    animate="visible"
-                    exit="exit"
-                    transition={{
-                      duration: dur(0.4),
-                      ease: "easeOut",
-                      when: "beforeChildren",
-                      staggerChildren: dur(0.1),
-                    }}
-                  >
-                    <nav className="flex-1 flex flex-col space-y-4 mt-16 px-6">
-                      {navigationItems.map(
-                        (
-                          item,
-                        ) => {
-                          const isActive =
-                            !item.external &&
-                            currentPath ===
-                              item.href;
-                          return (
-                            <motion.div
-                              key={
-                                item.name
-                              }
-                              variants={sheetItemVariants}
-                              transition={{
-                                duration: dur(0.4),
-                                ease: "easeOut"
-                              }}
-                            >
-                              <Link
-                                to={
-                                  item.href
-                                }
-                                onClick={() =>
-                                  setOpen(
-                                    false,
-                                  )
-                                }
-                                className={cn(
-                                  "block px-3 py-2 rounded-md text-base font-medium transition-colors",
-                                  isActive
-                                    ? "bg-slate-800/80 text-slate-100 border border-slate-700/60"
-                                    : "text-slate-300 hover:bg-slate-800/60 hover:text-slate-100",
-                                )}
-                                style={{
-                                  fontFamily:
-                                    "var(--font-body)",
-                                }}
-                              >
-                                {
-                                  item.name
-                                }
-                              </Link>
-                            </motion.div>
-                          );
-                        },
+              Other
+            </NavigationMenuTrigger>
+            <NavigationMenuContent className="rounded-[var(--radius-sm)] border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-sm)]">
+              <ul className="grid w-56 gap-1 p-2">
+                {secondaryItems.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      to={item.href}
+                      className={cn(
+                        'block rounded-[var(--radius-xs)] px-3 py-3 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus:bg-[var(--surface-subtle)] focus:text-[var(--graphite)] focus-visible:outline-none',
+                        pathname === item.href && 'text-[var(--graphite)]',
                       )}
-                      
-                      <motion.div
-                        initial={{ opacity: 0, scale: 0.8 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        transition={{ delay: dur(0.5), duration: dur(0.3) }}
-                      >
-                        <Separator className="bg-slate-700/60" />
-                      </motion.div>
-                      
-                      <motion.div
-                        className="text-xs font-semibold text-slate-500 uppercase tracking-wider px-3 pt-2"
-                        initial={{ opacity: 0, x: -20 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{ delay: dur(0.6), duration: dur(0.3) }}
-                      >
-                        More
-                      </motion.div>
-                      
-                      {moreItems.map(
-                        (
-                          item,
-                        ) => {
-                          const isActive =
-                            currentPath ===
-                            item.href;
-                          return (
-                            <motion.div
-                              key={
-                                item.name
-                              }
-                              variants={sheetItemVariants}
-                              transition={{
-                                duration: dur(0.4),
-                                ease: "easeOut"
-                              }}
-                            >
-                              <Link
-                                to={
-                                  item.href
-                                }
-                                onClick={() =>
-                                  setOpen(
-                                    false,
-                                  )
-                                }
-                                className={cn(
-                                  "block px-3 py-2 rounded-md text-base font-medium transition-colors",
-                                  isActive
-                                    ? "bg-slate-800/80 text-slate-100 border border-slate-700/60"
-                                    : "text-slate-300 hover:bg-slate-800/60 hover:text-slate-100",
-                                )}
-                                style={{
-                                  fontFamily:
-                                    "var(--font-body)",
-                                }}
-                              >
-                                {
-                                  item.name
-                                }
-                              </Link>
-                            </motion.div>
-                          );
-                        },
-                      )}
-                    </nav>
-                    
-                    <motion.div
-                      className="border-t border-slate-800/70 p-6 space-y-3"
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: dur(0.8), duration: dur(0.4) }}
                     >
-                      <motion.a
-                        href="https://www.linkedin.com/in/naufaldirafif/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center justify-center gap-2 w-full rounded-md border border-slate-700/70 bg-slate-800/80 px-4 py-3 text-sm text-slate-100 hover:bg-slate-800/90 hover:border-slate-600/70 transition-colors"
-                        style={{
-                          fontFamily:
-                            "var(--font-body)",
-                          fontWeight: 600,
-                        }}
-                        whileHover={prefersReducedMotion ? {} : { scale: 1.02 }}
-                        whileTap={prefersReducedMotion ? {} : { scale: 0.98 }}
-                        transition={{ duration: dur(0.2) }}
-                      >
-                        Contact
-                        <ArrowRight className="h-4 w-4" />
-                      </motion.a>
-                      <motion.a
-                        href="#"
-                        className="flex items-center justify-center gap-2 w-full rounded-md bg-slate-100 text-slate-900 px-4 py-3 text-sm hover:bg-white transition-colors font-semibold"
-                        style={{
-                          fontFamily:
-                            "var(--font-body)",
-                          fontWeight: 600,
-                        }}
-                        whileHover={prefersReducedMotion ? {} : { scale: 1.02 }}
-                        whileTap={prefersReducedMotion ? {} : { scale: 0.98 }}
-                        transition={{ duration: dur(0.2) }}
-                      >
-                        Download
-                        CV
-                        <ArrowRight className="h-4 w-4" />
-                      </motion.a>
-                    </motion.div>
-                  </motion.div>
-                </SheetContent>
-              </>
-            )}
-          </AnimatePresence>
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
+
+      <div className="md:hidden">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="icon" aria-label="Open navigation menu">
+              <Menu className="h-4 w-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="w-full max-w-sm">
+            <SheetTitle className="font-mono text-sm uppercase tracking-[0.14em]">Route index</SheetTitle>
+            <nav className="mt-10 grid gap-1" aria-label="Mobile navigation">
+              {[...navigationItems, ...secondaryItems].map((item) => (
+                <Link
+                  key={item.name}
+                  to={item.href}
+                  onClick={() => setOpen(false)}
+                  className={cn(
+                    'border-b border-[var(--border-line)] py-4 font-mono text-sm uppercase tracking-[0.12em] text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)]',
+                    pathname === item.href && 'text-[var(--graphite)]',
+                  )}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </nav>
+          </SheetContent>
         </Sheet>
       </div>
     </>
-  );
+  )
 }

--- a/src/components/common/ThemeProvider.tsx
+++ b/src/components/common/ThemeProvider.tsx
@@ -22,7 +22,7 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
 export function ThemeProvider({
   children,
-  defaultTheme = "dark",
+  defaultTheme = "light",
   storageKey = "vite-ui-theme",
   ...props
 }: ThemeProviderProps) {
@@ -71,4 +71,3 @@ export const useTheme = () => {
 
   return context
 }
-

--- a/src/components/design-system/DividerRow.tsx
+++ b/src/components/design-system/DividerRow.tsx
@@ -1,0 +1,22 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { cn } from '@/lib'
+
+interface DividerRowProps extends ComponentPropsWithoutRef<'article'> {}
+
+export default function DividerRow({ children, className, ...props }: DividerRowProps) {
+  return (
+    <article
+      className={cn(
+        'group/row relative border-b border-[var(--border-line)] py-6',
+        className,
+      )}
+      {...props}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-2 left-3 right-3 bg-[var(--surface-subtle)]/70 opacity-0 transition-opacity duration-200 group-hover/row:opacity-100 md:left-4 md:right-4"
+      />
+      <div className="relative">{children}</div>
+    </article>
+  )
+}

--- a/src/components/design-system/DrawingFrame.tsx
+++ b/src/components/design-system/DrawingFrame.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib'
+
+interface DrawingFrameProps {
+  children: ReactNode
+  className?: string
+  innerClassName?: string
+}
+
+export default function DrawingFrame({
+  children,
+  className,
+  innerClassName,
+}: DrawingFrameProps) {
+  return (
+    <section className={cn('drawing-sheet relative overflow-hidden', className)}>
+      <div className="pointer-events-none absolute inset-x-4 top-0 bottom-0 hidden drawing-rail md:block" />
+      <div className="pointer-events-none absolute left-[8%] top-0 bottom-0 hidden border-l border-dashed border-[var(--border-dashed)] opacity-70 lg:block" />
+      <div className="pointer-events-none absolute right-[8%] top-0 bottom-0 hidden border-l border-dashed border-[var(--border-dashed)] opacity-70 lg:block" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.72),rgba(255,255,255,0.24)_34%,rgba(255,255,255,0.82)_100%)] dark:bg-[linear-gradient(180deg,rgba(9,10,12,0.58),rgba(9,10,12,0.2)_34%,rgba(9,10,12,0.82)_100%)]" />
+      <div className={cn('site-container relative', innerClassName)}>
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/src/components/design-system/ExperienceRow.tsx
+++ b/src/components/design-system/ExperienceRow.tsx
@@ -1,0 +1,124 @@
+import type { WorkExperience } from '@/data/experience'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { cn } from '@/lib'
+import DividerRow from './DividerRow'
+import { TechnicalLabel } from './TechnicalLabel'
+
+const employmentTypeLabels: Record<WorkExperience['employmentType'], string> = {
+  'full-time': 'Full-time',
+  freelance: 'Freelance',
+  contract: 'Contract',
+}
+
+interface ExperienceRowProps {
+  experience: WorkExperience
+  index: number
+}
+
+export default function ExperienceRow({ experience, index }: ExperienceRowProps) {
+  const isCurrent = experience.endDate === 'Present'
+  const rowNumber = String(index + 1).padStart(2, '0')
+  const headingId = `experience-${experience.id}-heading`
+
+  return (
+    <DividerRow
+      aria-labelledby={headingId}
+      className={cn(
+        'group relative overflow-hidden py-7 md:py-8',
+      )}
+    >
+      {isCurrent && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-2 left-3 right-3 bg-[var(--surface-subtle)]/55 md:left-4 md:right-4"
+        />
+      )}
+
+      <div
+        aria-hidden="true"
+        className={cn(
+          'absolute left-[112px] top-8 hidden h-2.5 w-2.5 -translate-x-1/2 rounded-full border border-[var(--border-dashed)] bg-[var(--paper)] md:block lg:left-36',
+          isCurrent && 'border-[var(--status-green)] bg-[var(--status-green)]',
+        )}
+      />
+
+      <div className="relative grid gap-5 md:grid-cols-[112px_minmax(0,1fr)_minmax(220px,320px)] md:items-start lg:grid-cols-[144px_minmax(0,1fr)_minmax(240px,360px)]">
+        <div className="text-drawing-label">
+          <span>{rowNumber} // ROLE</span>
+          {isCurrent && (
+            <span
+              aria-hidden="true"
+              className="ml-3 inline-block h-2 w-2 rounded-full bg-[var(--status-green)] md:hidden"
+            />
+          )}
+        </div>
+
+        <div className="max-w-3xl space-y-5">
+          <div className="space-y-1">
+            <h3
+              id={headingId}
+              className="font-mono text-2xl font-medium leading-tight text-[var(--graphite)] md:text-3xl"
+            >
+              {experience.companyName}
+            </h3>
+            <p className="text-sm font-medium text-[var(--graphite-muted)]">{experience.role}</p>
+          </div>
+
+          <p className="max-w-2xl text-sm leading-7 text-[var(--graphite-muted)] md:text-base">
+            {experience.description}
+          </p>
+        </div>
+
+        <div className="space-y-4 md:text-right">
+          <div className="flex flex-wrap gap-2 md:justify-end">
+            {isCurrent && <TechnicalLabel variant="status">Current</TechnicalLabel>}
+            <TechnicalLabel variant="outline">
+              {employmentTypeLabels[experience.employmentType]}
+            </TechnicalLabel>
+          </div>
+
+          <dl className="grid gap-1">
+            <dt className="sr-only">Period</dt>
+            <dd className="font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)]">
+              {experience.startDate} - {experience.endDate}
+            </dd>
+          </dl>
+
+          <div className="flex flex-wrap gap-2 md:justify-end" aria-label="Technology stack">
+            {experience.techStack.slice(0, 4).map((tech) => (
+              <TechnicalLabel key={tech} variant="outline">
+                {tech}
+              </TechnicalLabel>
+            ))}
+          </div>
+        </div>
+
+        {experience.achievements.length > 0 && (
+          <div className="md:col-span-2 md:col-start-2">
+            <Accordion className="w-full">
+              <AccordionTrigger
+                aria-label={`Toggle key achievements for ${experience.companyName}`}
+                className="min-h-11 rounded-none border-t border-[var(--border-line)] px-0 pt-4 text-left font-mono text-xs uppercase tracking-[0.14em] text-[var(--graphite-muted)] hover:bg-transparent hover:text-[var(--graphite)] focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)]"
+              >
+                <span>View key achievements</span>
+              </AccordionTrigger>
+              <AccordionContent className="pt-4">
+                <ul className="grid gap-3 text-sm leading-7 text-[var(--graphite-muted)] md:max-w-3xl">
+                  {experience.achievements.map((achievement) => (
+                    <li key={achievement} className="border-l border-[var(--border-line)] pl-4">
+                      {achievement}
+                    </li>
+                  ))}
+                </ul>
+              </AccordionContent>
+            </Accordion>
+          </div>
+        )}
+      </div>
+    </DividerRow>
+  )
+}

--- a/src/components/design-system/FooterColumn.tsx
+++ b/src/components/design-system/FooterColumn.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib'
+
+interface FooterColumnProps {
+  title: string
+  children: ReactNode
+  className?: string
+}
+
+export default function FooterColumn({ title, children, className }: FooterColumnProps) {
+  return (
+    <nav className={cn('space-y-4', className)} aria-label={title}>
+      <h3 className="text-drawing-label">{title}</h3>
+      <div className="flex flex-col gap-3">{children}</div>
+    </nav>
+  )
+}

--- a/src/components/design-system/MetadataRow.tsx
+++ b/src/components/design-system/MetadataRow.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib'
+
+interface MetadataRowProps {
+  items: string[]
+  className?: string
+}
+
+export default function MetadataRow({ items, className }: MetadataRowProps) {
+  return (
+    <dl className={cn('flex flex-wrap items-center gap-x-4 gap-y-2 text-meta', className)}>
+      {items.map((item, index) => (
+        <div key={item} className="flex items-center gap-4">
+          {index > 0 && <span className="h-3 w-px bg-[var(--border-line)]" aria-hidden="true" />}
+          <dt className="sr-only">Metadata</dt>
+          <dd>{item}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/design-system/SectionHeader.tsx
+++ b/src/components/design-system/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib'
+
+interface SectionHeaderProps {
+  number: string
+  label: string
+  title: string
+  titleId?: string
+  description?: string
+  action?: ReactNode
+  className?: string
+}
+
+export default function SectionHeader({
+  number,
+  label,
+  title,
+  titleId,
+  description,
+  action,
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div className={cn('section-rule grid gap-5 pt-5 md:grid-cols-[minmax(0,1fr)_auto]', className)}>
+      <div className="space-y-4">
+        <div className="text-drawing-label">
+          {number} // {label}
+        </div>
+        <div className="space-y-2">
+          <h2 id={titleId} className="text-section-title text-[var(--graphite)]">{title}</h2>
+          {description && <p className="text-body-readable">{description}</p>}
+        </div>
+      </div>
+      {action && <div className="self-end">{action}</div>}
+    </div>
+  )
+}

--- a/src/components/design-system/TechnicalLabel.tsx
+++ b/src/components/design-system/TechnicalLabel.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib'
+
+interface TechnicalLabelProps {
+  children: ReactNode
+  className?: string
+  variant?: 'mono' | 'status' | 'outline'
+}
+
+export function TechnicalLabel({
+  children,
+  className,
+  variant = 'mono',
+}: TechnicalLabelProps) {
+  return (
+    <span
+      className={cn(
+        'mono-label inline-flex items-center gap-2 text-[11px] leading-none text-[var(--graphite-muted)]',
+        variant === 'status' &&
+          'text-[var(--status-green)] before:h-2 before:w-2 before:rounded-full before:bg-[var(--status-green)]',
+        variant === 'outline' &&
+          'border border-dashed border-[var(--border-dashed)] px-2 py-1 text-[var(--graphite-muted)]',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}

--- a/src/components/design-system/WorkRow.tsx
+++ b/src/components/design-system/WorkRow.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { ArrowUpRight } from 'lucide-react'
+import { Link } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib'
+import DividerRow from './DividerRow'
+import { TechnicalLabel } from './TechnicalLabel'
+import type { PortfolioItem } from '@/data/portfolio'
+
+interface WorkRowProps {
+  item: PortfolioItem
+  index: number
+}
+
+export default function WorkRow({ item, index }: WorkRowProps) {
+  const [imageFailed, setImageFailed] = useState(false)
+  const rowNumber = String(index + 1).padStart(2, '0')
+  const headingId = `work-${item.id}-heading`
+  const projectType = item.type === 'blog' ? 'Writing' : 'Project'
+  const displayDate = item.date ? item.date.slice(0, 4) : 'Live'
+
+  return (
+    <DividerRow aria-labelledby={headingId} className="relative overflow-hidden py-7 md:py-8">
+      <div
+        aria-hidden="true"
+        className="absolute left-[112px] top-8 hidden h-2.5 w-2.5 -translate-x-1/2 rounded-full border border-[var(--border-dashed)] bg-[var(--paper)] transition-colors group-hover/row:border-[var(--graphite-muted)] md:block lg:left-36"
+      />
+
+      <div className="relative grid gap-5 md:grid-cols-[112px_minmax(0,1fr)_minmax(260px,380px)] md:items-start lg:grid-cols-[144px_minmax(0,1fr)_minmax(320px,430px)]">
+        <div className="text-drawing-label">{rowNumber} // WORK</div>
+
+        <div className="max-w-3xl space-y-5">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <TechnicalLabel variant="mono">{projectType}</TechnicalLabel>
+              <TechnicalLabel variant="outline">{displayDate}</TechnicalLabel>
+            </div>
+
+            <h3
+              id={headingId}
+              className="max-w-3xl font-mono text-2xl font-medium leading-tight text-[var(--graphite)] md:text-3xl"
+            >
+              {item.title}
+            </h3>
+            <p className="max-w-2xl text-sm leading-7 text-[var(--graphite-muted)] md:text-base">
+              {item.description}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2" aria-label="Technology stack">
+            {item.techStack.slice(0, 5).map((tech) => (
+              <TechnicalLabel key={tech} variant="outline">
+                {tech}
+              </TechnicalLabel>
+            ))}
+            {item.techStack.length > 5 && (
+              <TechnicalLabel variant="outline">+{item.techStack.length - 5}</TechnicalLabel>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="viewport-frame drawing-grid relative aspect-[16/9] overflow-hidden bg-[var(--paper)]">
+            {imageFailed ? (
+              <div className="flex h-full items-center justify-center px-6 text-center font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)]">
+                {item.title}
+              </div>
+            ) : (
+              <img
+                src={item.image}
+                alt={`${item.title} project preview`}
+                className={cn(
+                  'h-full w-full object-cover grayscale transition duration-300 group-hover/row:opacity-100 group-hover/row:grayscale-0',
+                  'opacity-70',
+                )}
+                loading="lazy"
+                decoding="async"
+                onError={() => setImageFailed(true)}
+              />
+            )}
+            <span className="coordinate-label absolute left-3 top-3">PREVIEW</span>
+            <span className="coordinate-label absolute bottom-3 right-3">WORK_{rowNumber}</span>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-[var(--border-line)] pt-3">
+            <span className="text-drawing-label">ROUTE_PROJECT</span>
+            <Button asChild variant="technical" className="w-fit">
+              <Link to={`/projects/${item.slug}`}>
+                Brief
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </DividerRow>
+  )
+}

--- a/src/components/homepage/ExperienceSection.tsx
+++ b/src/components/homepage/ExperienceSection.tsx
@@ -1,99 +1,97 @@
-import { ArrowRight } from "lucide-react";
-import { Link } from "react-router";
-import { getLatestExperiences } from "@/data/experience";
-import ExperienceCard from "./ExperienceCard";
-import FadeInUp from "@/components/common/FadeInUp";
+import { ArrowRight } from 'lucide-react'
+import { Link } from 'react-router'
+import { getLatestExperiences, workExperiences } from '@/data/experience'
+import { siteConfig } from '@/data/site'
+import ExperienceRow from '@/components/design-system/ExperienceRow'
+import SectionHeader from '@/components/design-system/SectionHeader'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
+import FadeInUp from '@/components/common/FadeInUp'
+import { Button } from '@/components/ui/button'
 
 export default function ExperienceSection() {
-  const latestExperiences =
-    getLatestExperiences(
-      4,
-    );
+  const latestExperiences = getLatestExperiences(4)
+  const currentRole = latestExperiences.find((experience) => experience.endDate === 'Present')
+  const experienceSignals = [
+    {
+      label: 'TIMELINE_SPAN',
+      value: siteConfig.stats.experience,
+      detail: 'Professional experience',
+    },
+    {
+      label: 'CURRENT_NODE',
+      value: currentRole?.companyName ?? 'Available',
+      detail: currentRole?.role ?? 'Open to work',
+    },
+    {
+      label: 'ROLE_INDEX',
+      value: `${workExperiences.length} roles`,
+      detail: 'Product delivery, system ownership, and engineering breadth',
+    },
+  ]
 
   return (
-    <section
-      id="experience"
-      aria-labelledby="experience-heading"
-      className="bg-slate-950 light:bg-slate-50 px-6 md:px-0 py-12 md:py-16"
-    >
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <div className="space-y-6 sm:space-y-8">
-          <FadeInUp
-            delay={
-              0.06
+    <section id="experience" aria-labelledby="experience-heading" className="py-16 md:py-24">
+      <div className="site-container">
+        <FadeInUp delay={0.06}>
+          <SectionHeader
+            number="02"
+            label="EXPERIENCE_ROW"
+            title="Experience"
+            titleId="experience-heading"
+            description="Evolving into a broader software engineer through product delivery, system ownership, and team collaboration."
+            action={
+              <Button asChild variant="technical">
+                <Link to="/experience">
+                  View all experience
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
             }
-          >
-            <div className="space-y-2">
-              <h2
-                id="experience-heading"
-                className="text-[24px] md:text-[28px] text-slate-100 light:text-slate-900 tracking-tight font-mono font-medium"
-              >
-                Experience
-              </h2>
-              <p
-                className="text-sm text-slate-400 light:text-slate-600 max-w-2xl font-body font-medium"
-              >
-                Building
-                products
-                and
-                leading
-                teams
-                across
-                startups
-                and
-                companies
-              </p>
-            </div>
-          </FadeInUp>
+          />
+        </FadeInUp>
 
-          <FadeInUp
-            delay={
-              0.12
-            }
-          >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 items-start">
-              {latestExperiences.map(
-                (
-                  experience,
-                  index,
-                ) => (
-                  <ExperienceCard
-                    key={
-                      experience.id
-                    }
-                    experience={
-                      experience
-                    }
-                    index={
-                      index
-                    }
-                  />
-                ),
-              )}
-            </div>
-          </FadeInUp>
-
-          <FadeInUp
-            delay={
-              0.12 +
-              latestExperiences.length *
-                0.1
-            }
-          >
-            <div className="flex justify-center pt-4">
-              <Link
-                to="/experience"
-                className="group inline-flex items-center gap-2 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-6 py-3 text-sm text-slate-300 light:text-slate-700 transition-all duration-200 hover:text-slate-100 light:hover:text-slate-900 hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-md hover:shadow-slate-900/50 light:hover:shadow-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-semibold"
+        <FadeInUp delay={0.12}>
+          <div className="mt-8 grid gap-px border-y border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-3">
+            {experienceSignals.map((signal, index) => (
+              <div
+                key={signal.label}
+                className="bg-[var(--paper)] px-4 py-4 md:px-5"
               >
-                View
-                all
-                experience
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-              </Link>
-            </div>
-          </FadeInUp>
-        </div>
+                <div className="text-drawing-label">
+                  {String(index + 1).padStart(2, '0')} // {signal.label}
+                </div>
+                <div className="mt-4 flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-mono text-xl font-medium leading-none text-[var(--graphite)] md:text-2xl">
+                      {signal.value}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--graphite-muted)]">
+                      {signal.detail}
+                    </p>
+                  </div>
+                  {signal.label === 'CURRENT_NODE' && (
+                    <TechnicalLabel variant="status" className="mt-1">
+                      Live
+                    </TechnicalLabel>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </FadeInUp>
+
+        <FadeInUp delay={0.18}>
+          <div className="relative mt-8 border-t border-[var(--border-line)]">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+            />
+            {latestExperiences.map((experience, index) => (
+              <ExperienceRow key={experience.id} experience={experience} index={index} />
+            ))}
+          </div>
+        </FadeInUp>
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -1,101 +1,164 @@
-import {
-  Sparkles,
-  Code2,
-  ArrowRight,
-} from "lucide-react";
-import { siteConfig } from "@/data/site";
-import CodePreviewCard from "./CodePreviewCard";
-import StatsCards from "./StatsCards";
+import { ArrowRight, Code2 } from "lucide-react";
 import FadeInUp from "@/components/common/FadeInUp";
+import DrawingFrame from "@/components/design-system/DrawingFrame";
+import MetadataRow from "@/components/design-system/MetadataRow";
+import { TechnicalLabel } from "@/components/design-system/TechnicalLabel";
+import { siteConfig } from "@/data/site";
+
+const heroRoutes = [
+  {
+    index: "01",
+    label: "View projects",
+    href: "#projects",
+    icon: <Code2 className="h-4 w-4" aria-hidden="true" />,
+  },
+  {
+    index: "02",
+    label: "Get in touch",
+    href: siteConfig.socialLinks.linkedin ?? "#",
+  },
+  {
+    index: "03",
+    label: "Download CV",
+    href: siteConfig.socialLinks.linkedin ?? "#",
+  },
+];
+
+const heroSkills = ["Product Systems", "Backend Foundations", "Engineering Mentorship"];
 
 export default function HeroSection() {
   return (
-    <section className="relative flex-1" aria-label="Introduction">
-      <div className="mx-auto max-w-7xl px-6">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 sm:gap-10 lg:gap-16 items-center pb-12 pt-8 sm:pt-16 lg:pt-24">
-          <FadeInUp
-            delay={
-              0.12
-            }
-          >
-            <div className="space-y-7">
-              <div className="inline-flex items-center gap-2 rounded-full border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-slate-100 px-2.5 py-1 text-[11px] text-slate-300 light:text-slate-800">
-                <Sparkles className="h-3.5 w-3.5 text-slate-300/90 light:text-slate-800/90" />
-                <span
-                  className="font-body font-medium"
-                >
-                  {
-                    siteConfig.statusBadge
-                  }
-                </span>
-                <span
-                  className="mx-1.5 h-1 w-1 rounded-full bg-slate-700 light:bg-slate-500"
-                  aria-hidden="true"
-                />
-                <a
-                  href="https://www.linkedin.com/in/naufaldirafif/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline decoration-slate-600 light:decoration-slate-600 underline-offset-2 hover:text-slate-100 light:hover:text-slate-950 hover:decoration-slate-400 light:hover:decoration-slate-800 transition-colors font-body font-medium"
-                >
-                  {
-                    siteConfig.availability
-                  }
-                </a>
-              </div>
-
-              <h1
-                className="text-2xl sm:text-[32px] md:text-[40px] leading-[1.15] text-slate-100 light:text-slate-950 tracking-tight font-mono font-medium"
-              >
-                {
-                  siteConfig.tagline
-                }
-              </h1>
-
-              <p
-                className="text-base md:text-lg text-slate-400 light:text-slate-700 max-w-2xl font-body font-medium"
-              >
-                {
-                  siteConfig.bio
-                }
-              </p>
-
-              <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                <a
-                  href="#projects"
-                  className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-100 light:bg-slate-950 text-slate-900 light:text-white px-4 py-2.5 text-sm hover:bg-white light:hover:bg-slate-900 hover:shadow-lg hover:shadow-slate-900/20 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-950/40 transition-colors font-body font-semibold"
-                >
-                  <Code2 className="h-[18px] w-[18px]" />
-                  View
-                  projects
-                </a>
-                <a
-                  href="https://www.linkedin.com/in/naufaldirafif/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-800/70 light:border-slate-400 bg-slate-900/60 light:bg-white px-4 py-2.5 text-sm text-slate-300 light:text-slate-800 hover:text-slate-100 light:hover:text-slate-950 hover:border-slate-700/70 light:hover:border-slate-600 hover:bg-slate-900/90 light:hover:bg-slate-50 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/30 transition-colors font-body font-semibold"
-                >
-                  Get
-                  in
-                  touch
-                  <ArrowRight className="h-4 w-4 -mr-0.5" />
-                </a>
-              </div>
-            </div>
-          </FadeInUp>
-
-          <FadeInUp
-            delay={
-              0.22
-            }
-          >
-            <div className="relative">
-              <CodePreviewCard />
-              <StatsCards />
-            </div>
-          </FadeInUp>
-        </div>
+    <DrawingFrame
+      className="min-h-[calc(100dvh-72px)]"
+      innerClassName="min-h-[calc(100dvh-72px)]"
+    >
+      <div className="pointer-events-none absolute inset-x-5 top-10 bottom-10 hidden md:block">
+        <div className="absolute left-[8%] right-[8%] top-[18%] border-t border-dashed border-[var(--border-dashed)]" />
+        <div className="absolute left-[8%] right-[8%] top-[48%] border-t border-dashed border-[var(--border-dashed)]" />
+        <div className="absolute left-[8%] right-[8%] bottom-[18%] border-t border-[var(--border-line)]" />
+        <div className="absolute left-[8%] top-10 bottom-10 border-l border-dashed border-[var(--border-dashed)]" />
+        <div className="absolute left-[58%] top-10 bottom-10 border-l border-dashed border-[var(--border-dashed)]" />
+        <div className="absolute right-[9%] top-10 bottom-10 border-l border-dashed border-[var(--border-dashed)]" />
+        <span className="coordinate-label absolute left-[8%] top-8">
+          X-1440
+        </span>
+        <span className="coordinate-label absolute left-[58%] top-8">
+          X-768
+        </span>
+        <span className="coordinate-label absolute right-[8%] top-8">
+          X-0
+        </span>
+        <span className="coordinate-label absolute left-[7%] top-[18%]">
+          Y-0
+        </span>
+        <span className="coordinate-label absolute left-[7%] top-[48%]">
+          Y-360
+        </span>
+        <span className="coordinate-label absolute left-[7%] bottom-[18%]">
+          Y-720
+        </span>
       </div>
-    </section>
+
+      <div className="grid min-h-[calc(100dvh-72px)] items-center py-20 md:py-24">
+        <FadeInUp delay={0.12}>
+          <div className="relative mx-auto w-full max-w-[1180px] border border-[var(--border-line)] bg-[var(--paper)]/62 p-5 shadow-[var(--shadow-paper-xs)] md:p-8">
+            <div
+              className="absolute left-0 top-0 h-px w-32 bg-[var(--status-green)]"
+              aria-hidden="true"
+            />
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
+              <div className="space-y-7">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <TechnicalLabel variant="mono">01 // INTRO</TechnicalLabel>
+                  <div className="hidden gap-8 md:flex">
+                    <span className="coordinate-label">X-1024</span>
+                    <span className="coordinate-label">X-768</span>
+                    <span className="coordinate-label">X-480</span>
+                  </div>
+                </div>
+
+                <div className="border border-[var(--border-line)] bg-[var(--paper)] px-4 py-5 md:px-6 md:py-7">
+                  <h1 className="font-display text-[clamp(3.1rem,6.8vw,7.15rem)] font-black uppercase leading-[0.86] tracking-normal text-[var(--graphite)]">
+                    NAUFALDI RAFIF S.
+                  </h1>
+                </div>
+
+                <div className="max-w-2xl space-y-4 md:pl-6">
+                  <h2 className="font-mono text-2xl leading-tight text-[var(--graphite)] md:text-3xl">
+                    Software Engineer & Mentor
+                  </h2>
+                  <MetadataRow items={heroSkills} />
+                  <p className="text-body-readable">
+                    My foundation is frontend, but the direction is broader:
+                    backend ownership, product architecture, and end-to-end
+                    software delivery.
+                  </p>
+                </div>
+              </div>
+
+              <aside
+                className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
+                aria-label="Hero routes"
+              >
+                <TechnicalLabel variant="mono">02 // ROUTES</TechnicalLabel>
+                <div className="mt-8 divide-y divide-[var(--border-line)] border-y border-[var(--border-line)]">
+                  {heroRoutes.map((route, index) => {
+                    const isExternal = route.href.startsWith("http");
+
+                    return (
+                      <a
+                        key={route.label}
+                        href={route.href}
+                        target={isExternal ? "_blank" : undefined}
+                        rel={isExternal ? "noopener noreferrer" : undefined}
+                        className={
+                          index === 0
+                            ? "group flex items-center justify-between gap-4 border-l-2 border-l-[var(--status-green)] bg-[var(--graphite)] px-4 py-4 text-sm font-medium text-[var(--paper)] transition-colors hover:bg-[var(--graphite-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)]"
+                            : "group flex items-center justify-between gap-4 border-l-2 border-l-transparent bg-[var(--paper)] px-4 py-4 text-sm text-[var(--graphite)] transition-colors hover:border-l-[var(--status-green)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)]"
+                        }
+                      >
+                        <span className="grid gap-3">
+                          <span
+                            className={
+                              index === 0
+                                ? "font-mono text-[11px] tracking-[0.14em] text-[var(--status-green)]"
+                                : "text-drawing-label"
+                            }
+                          >
+                            {route.index}
+                          </span>
+                          <span className="inline-flex items-center gap-2">
+                            {route.icon}
+                            {route.label}
+                          </span>
+                        </span>
+                        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                      </a>
+                    );
+                  })}
+                </div>
+              </aside>
+            </div>
+
+            <div className="mt-9 border-t border-[var(--border-line)] pt-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <MetadataRow
+                  items={[
+                    "Open to work",
+                    `${siteConfig.stats.experience} experience`,
+                    `${siteConfig.stats.mentees} mentees`,
+                    "Bekasi, Indonesia",
+                  ]}
+                />
+                <div className="flex gap-5">
+                  <TechnicalLabel variant="mono">BUILD:2026</TechnicalLabel>
+                  <TechnicalLabel variant="mono">PRD:01</TechnicalLabel>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FadeInUp>
+      </div>
+    </DrawingFrame>
   );
 }

--- a/src/components/homepage/MentorSpeakerItem.tsx
+++ b/src/components/homepage/MentorSpeakerItem.tsx
@@ -1,153 +1,60 @@
-import { useState } from "react";
-import {
-  Twitter,
-  Linkedin,
-  ExternalLink,
-  Youtube,
-} from "lucide-react";
-import type { MentorSpeakerItem } from "@/data/mentorSpeaker";
-import { cn } from "@/lib";
-import FadeInUp from "@/components/common/FadeInUp";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowUpRight } from 'lucide-react'
+import type { MentorSpeakerItem as MentorSpeakerItemType } from '@/data/mentorSpeaker'
+import DividerRow from '@/components/design-system/DividerRow'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
+import { Button } from '@/components/ui/button'
 
 interface MentorSpeakerItemProps {
-  item: MentorSpeakerItem;
-  index: number;
+  item: MentorSpeakerItemType
+  index: number
 }
 
-export default function MentorSpeakerItem({
-  item,
-  index,
-}: MentorSpeakerItemProps) {
-  const [imgLoading, setImgLoading] = useState(true);
+export default function MentorSpeakerItem({ item, index }: MentorSpeakerItemProps) {
+  const primaryLink =
+    item.links?.website || item.links?.linkedin || item.links?.youtube || item.links?.x
+  const rowNumber = String(index + 1).padStart(2, '0')
+  const headingId = `mentor-speaker-${item.id}-heading`
+  const typeLabel = item.type === 'mentoring' ? 'Mentoring' : item.type
 
   return (
-    <FadeInUp
-      delay={
-        0.12 +
-        index *
-          0.1
-      }
-    >
-      <article
-        className={cn(
-          "group flex flex-col sm:flex-row gap-4 sm:gap-6 py-4 sm:py-6 border-b border-slate-800/70 light:border-slate-300 transition-colors hover:bg-slate-900/30 light:hover:bg-slate-100",
-        )}
-      >
-        {item.image && (
-          <div className="relative flex-shrink-0 w-full sm:w-56 md:w-64 h-32 sm:h-32 rounded-lg overflow-hidden shadow-sm">
-            {imgLoading && (
-              <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-slate-800/60" />
-            )}
-            <img
-              src={
-                item.image
-              }
-              alt={`${item.eventName} banner`}
-              className="w-full h-full object-cover"
-              loading="lazy"
-              onLoad={() => setImgLoading(false)}
-            />
-          </div>
-        )}
-        <div className="flex-1 flex flex-col justify-between gap-3 sm:gap-4">
-          <div className="space-y-1.5 sm:space-y-2">
+    <DividerRow aria-labelledby={headingId} className="relative overflow-hidden py-7 md:py-8">
+      <div
+        aria-hidden="true"
+        className="absolute left-[112px] top-8 hidden h-2.5 w-2.5 -translate-x-1/2 rounded-full border border-[var(--border-dashed)] bg-[var(--paper)] transition-colors group-hover/row:border-[var(--graphite-muted)] md:block lg:left-36"
+      />
+
+      <div className="relative grid gap-5 md:grid-cols-[112px_minmax(0,1fr)_minmax(180px,280px)] md:items-start lg:grid-cols-[144px_minmax(0,1fr)_minmax(220px,320px)]">
+        <div className="text-drawing-label">{rowNumber} // {item.type}</div>
+
+        <div className="max-w-3xl space-y-4">
+          <div className="space-y-2">
+            <TechnicalLabel variant="mono">{typeLabel}</TechnicalLabel>
             <h3
-              className="text-lg sm:text-xl md:text-2xl text-slate-100 light:text-slate-900 font-mono font-medium"
+              id={headingId}
+              className="font-mono text-2xl font-medium leading-tight text-[var(--graphite)] md:text-3xl"
             >
-              {
-                item.eventName
-              }
+            {item.eventName}
             </h3>
-            <p
-              className="text-xs sm:text-sm md:text-base text-slate-400 light:text-slate-600 font-body font-medium"
-            >
-              {
-                item.brief
-              }
-            </p>
-            <p
-              className="text-xs text-slate-400 light:text-slate-600 font-body font-medium"
-            >
-              {
-                item.date
-              }
-            </p>
           </div>
-          {item.links && (
-            <div className="flex items-center gap-2 flex-wrap">
-              {item
-                .links
-                .x && (
-                <a
-                  href={
-                    item
-                      .links
-                      .x
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white text-slate-400 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40"
-                  aria-label={`View ${item.eventName} on X`}
-                >
-                  <Twitter className="h-4 w-4" />
+          <p className="max-w-3xl text-sm leading-7 text-[var(--graphite-muted)] md:text-base">
+            {item.brief}
+          </p>
+        </div>
+
+        <div className="space-y-4 md:text-right">
+          <TechnicalLabel variant="outline">{item.date}</TechnicalLabel>
+          {primaryLink && (
+            <div className="md:flex md:justify-end">
+              <Button asChild variant="technical" size="sm">
+                <a href={primaryLink} target="_blank" rel="noopener noreferrer">
+                  Open
+                  <ArrowUpRight className="h-3.5 w-3.5" />
                 </a>
-              )}
-              {item
-                .links
-                .linkedin && (
-                <a
-                  href={
-                    item
-                      .links
-                      .linkedin
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white text-slate-400 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40"
-                  aria-label={`View ${item.eventName} on LinkedIn`}
-                >
-                  <Linkedin className="h-4 w-4" />
-                </a>
-              )}
-              {item
-                .links
-                .youtube && (
-                <a
-                  href={
-                    item
-                      .links
-                      .youtube
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white text-slate-400 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40"
-                  aria-label={`Watch ${item.eventName} on YouTube`}
-                >
-                  <Youtube className="h-4 w-4" />
-                </a>
-              )}
-              {item
-                .links
-                .website && (
-                <a
-                  href={
-                    item
-                      .links
-                      .website
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white text-slate-400 light:text-slate-600 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40"
-                  aria-label={`Visit ${item.eventName} website`}
-                >
-                  <ExternalLink className="h-4 w-4" />
-                </a>
-              )}
+              </Button>
             </div>
           )}
         </div>
-      </article>
-    </FadeInUp>
-  );
+      </div>
+    </DividerRow>
+  )
 }

--- a/src/components/homepage/MentorSpeakerSection.tsx
+++ b/src/components/homepage/MentorSpeakerSection.tsx
@@ -1,46 +1,97 @@
 import { ArrowRight } from 'lucide-react'
 import { Link } from 'react-router'
-import { getHomeMentorSpeakerPreview } from '@/data/mentorSpeaker'
+import {
+  getHomeMentorSpeakerPreview,
+  mentorSpeakerEngagements,
+} from '@/data/mentorSpeaker'
 import MentorSpeakerItem from './MentorSpeakerItem'
 import FadeInUp from '@/components/common/FadeInUp'
+import SectionHeader from '@/components/design-system/SectionHeader'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
+import { Button } from '@/components/ui/button'
 
 export default function MentorSpeakerSection() {
   const previewItems = getHomeMentorSpeakerPreview()
+  const speakerCount = mentorSpeakerEngagements.filter((item) => item.type === 'speaker').length
+  const mentoringCount = mentorSpeakerEngagements.filter((item) => item.type === 'mentoring').length
+  const signalItems = [
+    {
+      label: 'PUBLIC_WORK',
+      value: `${speakerCount} talks`,
+      detail: 'Workshops, meetups, and learning sessions',
+    },
+    {
+      label: 'MENTORSHIP_LOOP',
+      value: `${mentoringCount} programs`,
+      detail: 'Career guidance and software engineering mentoring',
+    },
+    {
+      label: 'FEATURED_SET',
+      value: `${previewItems.length} featured`,
+      detail: 'Selected engagements for the homepage',
+    },
+  ]
 
   return (
-    <section id="mentor-speaker" aria-labelledby="mentor-speaker-heading" className="relative bg-slate-950 light:bg-slate-50 px-6 md:px-0 py-12 md:py-16">
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <div className="space-y-8">
-          <FadeInUp delay={0.06}>
-            <h2
-              id="mentor-speaker-heading"
-              className="text-[24px] md:text-[28px] text-slate-100 light:text-slate-900 tracking-tight font-mono font-medium"
-            >
-              Mentor / Speaker
-            </h2>
-          </FadeInUp>
-          <FadeInUp delay={0.12}>
-            <div className="flex flex-col">
-              {previewItems.map((item, index) => (
-                <MentorSpeakerItem key={item.id} item={item} index={index} />
-              ))}
-            </div>
-          </FadeInUp>
+    <section id="mentor-speaker" aria-labelledby="mentor-speaker-heading" className="py-16 md:py-24">
+      <div className="site-container">
+        <FadeInUp delay={0.06}>
+          <SectionHeader
+            number="04"
+            label="MENTOR_SPEAKER_ROW"
+            title="Mentor / Speaker"
+            titleId="mentor-speaker-heading"
+            description="Workshops, mentoring programs, and talks about software engineering growth, product systems, and agentic workflows."
+            action={
+              <Button asChild variant="technical">
+                <Link to="/speaker">
+                  View all engagements
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            }
+          />
+        </FadeInUp>
 
-          <FadeInUp delay={0.12 + previewItems.length * 0.1}>
-            <div className="flex justify-center pt-4">
-            <Link
-              to="/speaker"
-              className="group inline-flex items-center gap-2 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-6 py-3 text-sm text-slate-300 light:text-slate-700 transition-all duration-200 hover:text-slate-100 light:hover:text-slate-950 hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-md hover:shadow-slate-900/50 light:hover:shadow-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-semibold"
-            >
-              View all engagements
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
+        <FadeInUp delay={0.12}>
+          <div className="mt-8 grid gap-px border-y border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-3">
+            {signalItems.map((signal, index) => (
+              <div key={signal.label} className="bg-[var(--paper)] px-4 py-4 md:px-5">
+                <div className="text-drawing-label">
+                  {String(index + 1).padStart(2, '0')} // {signal.label}
+                </div>
+                <div className="mt-4 flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-mono text-xl font-medium leading-none text-[var(--graphite)] md:text-2xl">
+                      {signal.value}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--graphite-muted)]">
+                      {signal.detail}
+                    </p>
+                  </div>
+                  {signal.label === 'FEATURED_SET' && (
+                    <TechnicalLabel variant="mono" className="mt-1">
+                      Live
+                    </TechnicalLabel>
+                  )}
+                </div>
+              </div>
+            ))}
           </div>
-          </FadeInUp>
-        </div>
+        </FadeInUp>
+
+        <FadeInUp delay={0.18}>
+          <div className="relative mt-8 border-t border-[var(--border-line)]">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+            />
+            {previewItems.map((item, index) => (
+              <MentorSpeakerItem key={item.id} item={item} index={index} />
+            ))}
+          </div>
+        </FadeInUp>
       </div>
     </section>
   )
 }
-

--- a/src/components/homepage/PortfolioSection.tsx
+++ b/src/components/homepage/PortfolioSection.tsx
@@ -1,47 +1,92 @@
-import { ArrowRight } from "lucide-react";
-import { Link } from "react-router";
-import { portfolioItems } from "@/data/portfolio";
-import PortfolioCard from "./PortfolioCard";
-import FadeInUp from "@/components/common/FadeInUp";
+import { ArrowRight } from 'lucide-react'
+import { Link } from 'react-router'
+import { portfolioItems } from '@/data/portfolio'
+import WorkRow from '@/components/design-system/WorkRow'
+import SectionHeader from '@/components/design-system/SectionHeader'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
+import FadeInUp from '@/components/common/FadeInUp'
+import { Button } from '@/components/ui/button'
 
 export default function PortfolioSection() {
-  return (
-    <section
-      id="projects"
-      aria-labelledby="projects-heading"
-      className="bg-slate-950 light:bg-slate-50 px-6 md:px-0 py-12 md:py-16"
-    >
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <div className="space-y-6 sm:space-y-8">
-          <FadeInUp delay={0.06}>
-            <h2
-              id="projects-heading"
-              className="text-[24px] md:text-[28px] text-slate-100 light:text-slate-900 tracking-tight font-mono font-medium"
-            >
-              Portfolio
-            </h2>
-          </FadeInUp>
-          <FadeInUp delay={0.12}>
-            <div className="grid grid-cols-1 gap-4 sm:gap-6 sm:grid-cols-2">
-              {portfolioItems.slice(0, 4).map((item, index) => (
-                <PortfolioCard key={item.id} item={item} index={index} />
-              ))}
-            </div>
-          </FadeInUp>
+  const featuredItems = portfolioItems.slice(0, 4)
+  const projectSignals = [
+    {
+      label: 'WORK_INDEX',
+      value: `${featuredItems.length} featured`,
+      detail: 'Selected recent builds',
+    },
+    {
+      label: 'SYSTEM_SCOPE',
+      value: 'Product systems',
+      detail: 'Interfaces, APIs, data flow, and workflow tools',
+    },
+    {
+      label: 'PRIMARY_OUTPUT',
+      value: 'Working software',
+      detail: 'Shipped systems shaped around practical workflows',
+    },
+  ]
 
-          <FadeInUp delay={0.12 + portfolioItems.length * 0.1}>
-            <div className="flex justify-center pt-4">
-              <Link
-                to="/projects"
-                className="group inline-flex items-center gap-2 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-6 py-3 text-sm text-slate-300 light:text-slate-700 transition-all duration-200 hover:text-slate-100 light:hover:text-slate-950 hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-md hover:shadow-slate-900/50 light:hover:shadow-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-semibold"
-              >
-                View all projects
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-              </Link>
-            </div>
-          </FadeInUp>
-        </div>
+  return (
+    <section id="projects" aria-labelledby="projects-heading" className="bg-[var(--paper)] py-16 md:py-24">
+      <div className="site-container">
+        <FadeInUp delay={0.06}>
+          <SectionHeader
+            number="03"
+            label="PORTFOLIO_WORK_ROW"
+            title="Portfolio"
+            titleId="projects-heading"
+            description="Selected products, systems, and experiments showing the move from interface craft toward broader software engineering."
+            action={
+              <Button asChild variant="technical">
+                <Link to="/projects">
+                  View all projects
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            }
+          />
+        </FadeInUp>
+
+        <FadeInUp delay={0.12}>
+          <div className="mt-8 grid gap-px border-y border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-3">
+            {projectSignals.map((signal, index) => (
+              <div key={signal.label} className="bg-[var(--paper)] px-4 py-4 md:px-5">
+                <div className="text-drawing-label">
+                  {String(index + 1).padStart(2, '0')} // {signal.label}
+                </div>
+                <div className="mt-4 flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-mono text-xl font-medium leading-none text-[var(--graphite)] md:text-2xl">
+                      {signal.value}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--graphite-muted)]">
+                      {signal.detail}
+                    </p>
+                  </div>
+                  {signal.label === 'WORK_INDEX' && (
+                    <TechnicalLabel variant="mono" className="mt-1">
+                      Live
+                    </TechnicalLabel>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </FadeInUp>
+
+        <FadeInUp delay={0.18}>
+          <div className="relative mt-8 border-t border-[var(--border-line)] bg-[var(--paper)]/72">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+            />
+            {featuredItems.map((item, index) => (
+              <WorkRow key={item.id} item={item} index={index} />
+            ))}
+          </div>
+        </FadeInUp>
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/sections/ConnectCTA.tsx
+++ b/src/components/sections/ConnectCTA.tsx
@@ -1,73 +1,124 @@
-import { Twitter, Linkedin } from 'lucide-react'
+import { ArrowUpRight, Linkedin, Mail, Twitter } from 'lucide-react'
 import { siteConfig } from '@/data/site'
-import { cn } from '@/lib'
+import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
+import { Button } from '@/components/ui/button'
 
 export default function ConnectCTA() {
+  const contactSignals = [
+    {
+      label: 'STATUS',
+      value: 'Open channel',
+      detail: 'Software engineering work, speaking, and mentorship',
+    },
+    {
+      label: 'LOCATION',
+      value: 'Bekasi',
+      detail: 'Indonesia based, remote friendly',
+    },
+    {
+      label: 'PRIMARY_ROUTE',
+      value: 'LinkedIn',
+      detail: 'Best path for work conversations',
+    },
+  ]
+
   return (
-    <section className="relative bg-slate-900 light:bg-slate-50 border-t border-slate-800/70 light:border-slate-300 px-6 md:px-0 py-12 md:py-16">
-      <div
-        className="absolute inset-0 opacity-30 light:opacity-20"
-        style={{
-          backgroundImage:
-            'radial-gradient(ellipse at top right, rgba(148, 163, 184, 0.15), transparent 50%)',
-        }}
-        aria-hidden="true"
-      />
-      <div className="relative max-w-7xl mx-auto px-4 md:px-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-12">
-          <div className="flex flex-col justify-center">
-            <h2 className="text-2xl md:text-3xl font-bold text-white light:text-slate-900 mb-4">
-              Connect with me
-            </h2>
-            <p className="text-sm md:text-base text-slate-400 light:text-slate-600 leading-relaxed">
-              Don't miss out 👋. Get updates on my latest work and insights.
-            </p>
+    <section
+      id="contact"
+      aria-labelledby="contact-heading"
+      className="border-y border-[var(--border-line)] bg-[var(--paper)] py-12 md:py-16"
+    >
+      <div className="site-container">
+        <div className="section-rule grid gap-8 pt-5 md:grid-cols-[minmax(0,1fr)_minmax(320px,560px)] md:items-end">
+          <div className="space-y-4">
+            <div className="text-drawing-label">05 // CONTACT_SURFACE</div>
+            <div className="space-y-2">
+              <h2
+                id="contact-heading"
+                className="font-mono text-3xl font-medium leading-none text-[var(--graphite)] md:text-5xl"
+              >
+                Connect with me
+              </h2>
+              <p className="text-body-readable">
+                Get updates on my latest software work, writing, and practical engineering notes.
+              </p>
+            </div>
           </div>
 
-          <div className="flex flex-col gap-3">
+          <div className="grid gap-3">
             {siteConfig.socialLinks.twitter && (
-              <a
-                href={siteConfig.socialLinks.twitter}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  'inline-flex items-center justify-between w-full px-6 py-3',
-                  'bg-slate-100 light:bg-slate-950 text-slate-900 light:text-white',
-                  'hover:bg-white light:hover:bg-slate-900 hover:shadow-md hover:shadow-slate-900/20 light:hover:shadow-slate-200',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
-                  'focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 light:focus-visible:ring-offset-white',
-                  'transition-all duration-200 rounded-md',
-                  'text-sm font-semibold'
-                )}
-              >
-                <span>Follow on X</span>
-                <Twitter className="w-5 h-5" aria-hidden="true" />
-              </a>
+              <Button asChild variant="primary" className="justify-between">
+                <a href={siteConfig.socialLinks.twitter} target="_blank" rel="noopener noreferrer">
+                  Follow on X
+                  <Twitter className="h-5 w-5" aria-hidden="true" />
+                </a>
+              </Button>
             )}
             {siteConfig.socialLinks.linkedin && (
-              <a
-                href={siteConfig.socialLinks.linkedin}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  'inline-flex items-center justify-between w-full px-6 py-3',
-                  'border border-slate-700/70 light:border-slate-300 bg-slate-800/90 light:bg-white text-slate-200 light:text-slate-800',
-                  'hover:text-white light:hover:text-slate-950 hover:bg-slate-800 light:hover:bg-slate-50 hover:border-slate-600/70 light:hover:border-slate-400',
-                  'hover:shadow-md hover:shadow-slate-900/30 light:hover:shadow-slate-200',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50',
-                  'focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 light:focus-visible:ring-offset-white',
-                  'transition-all duration-200 rounded-md',
-                  'text-sm font-medium'
-                )}
-              >
-                <span>Contact on LinkedIn</span>
-                <Linkedin className="w-5 h-5" aria-hidden="true" />
-              </a>
+              <Button asChild variant="secondary" className="justify-between">
+                <a href={siteConfig.socialLinks.linkedin} target="_blank" rel="noopener noreferrer">
+                  Contact on LinkedIn
+                  <Linkedin className="h-5 w-5" aria-hidden="true" />
+                </a>
+              </Button>
+            )}
+            {siteConfig.socialLinks.email && (
+              <Button asChild variant="technical" className="justify-between">
+                <a href={siteConfig.socialLinks.email}>
+                  Send email
+                  <Mail className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </Button>
             )}
           </div>
+        </div>
+
+        <div className="mt-8 grid gap-px border-y border-[var(--border-line)] bg-[var(--border-line)] md:grid-cols-3">
+          {contactSignals.map((signal, index) => (
+            <div key={signal.label} className="bg-[var(--paper)] px-4 py-3 md:px-5 md:py-4">
+              <div className="text-drawing-label">
+                {String(index + 1).padStart(2, '0')} // {signal.label}
+              </div>
+              <div className="mt-4 flex items-start justify-between gap-4">
+                <div>
+                    <p className="font-mono text-lg font-medium leading-none text-[var(--graphite)] md:text-xl">
+                    {signal.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--graphite-muted)]">
+                    {signal.detail}
+                  </p>
+                </div>
+                {signal.label === 'STATUS' && (
+                  <TechnicalLabel variant="status" className="mt-1">
+                    Live
+                  </TechnicalLabel>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 border-t border-[var(--border-line)]">
+          <a
+            href="/projects"
+            className="group/row relative grid min-h-16 items-center border-b border-[var(--border-line)] py-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]"
+          >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-2 left-3 right-3 bg-[var(--surface-subtle)]/70 opacity-0 transition-opacity duration-200 group-hover/row:opacity-100 md:left-4 md:right-4"
+            />
+            <span className="relative flex items-center justify-between gap-4">
+              <span>
+                <span className="text-drawing-label">04 // NEXT_ROUTE</span>
+                <span className="mt-2 block font-mono text-lg font-medium text-[var(--graphite)]">
+                  Browse selected work
+                </span>
+              </span>
+              <ArrowUpRight className="h-4 w-4 text-[var(--graphite)]" aria-hidden="true" />
+            </span>
+          </a>
         </div>
       </div>
     </section>
   )
 }
-

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,28 +5,30 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-sm)] text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] disabled:pointer-events-none disabled:opacity-45 active:translate-y-px [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-slate-100 light:bg-slate-950 text-slate-900 light:text-white hover:bg-white light:hover:bg-slate-900 focus-visible:ring-2 focus-visible:ring-[rgba(241,245,249,0.4)] light:focus-visible:ring-[rgba(15,23,42,0.4)] transition-colors",
+          "border border-[var(--graphite)] bg-[var(--graphite)] text-[var(--paper)] shadow-[var(--shadow-paper-xs)] hover:bg-[var(--graphite-muted)] hover:border-[var(--graphite-muted)]",
         primary:
-          "bg-slate-100 light:bg-slate-950 text-slate-900 light:text-white hover:bg-white light:hover:bg-slate-900 focus-visible:ring-2 focus-visible:ring-[rgba(241,245,249,0.4)] light:focus-visible:ring-[rgba(15,23,42,0.4)] transition-colors",
+          "border border-[var(--graphite)] bg-[var(--graphite)] text-[var(--paper)] shadow-[var(--shadow-paper-xs)] hover:bg-[var(--graphite-muted)] hover:border-[var(--graphite-muted)]",
         secondary:
-          "border border-[rgba(30,41,59,0.7)] light:border-slate-300 bg-[rgba(15,23,42,0.6)] light:bg-white text-slate-300 light:text-slate-800 hover:text-slate-100 light:hover:text-slate-950 hover:bg-[rgba(15,23,42,0.9)] light:hover:bg-slate-50 hover:border-[rgba(51,65,85,0.7)] light:hover:border-slate-400 focus-visible:ring-2 focus-visible:ring-[rgba(129,140,248,0.3)] light:focus-visible:ring-[rgba(15,23,42,0.3)] transition-colors",
+          "border border-[var(--border-line)] bg-[var(--surface-raised)] text-[var(--graphite)] hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)]",
         "secondary-elevated":
-          "border border-slate-700/70 light:border-slate-300 bg-slate-800/90 light:bg-slate-100 text-slate-200 light:text-slate-900 hover:text-white light:hover:text-slate-950 hover:bg-slate-800 light:hover:bg-slate-200 hover:border-slate-600/70 light:hover:border-slate-400 hover:shadow-md hover:shadow-slate-900/30 light:hover:shadow-slate-200 focus-visible:ring-2 focus-visible:ring-blue-400/50 light:focus-visible:ring-[rgba(15,23,42,0.5)] transition-all",
+          "border border-[var(--border-line)] bg-[var(--surface-raised)] text-[var(--graphite)] shadow-[var(--shadow-paper-sm)] hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)]",
         outline:
-          "border border-[rgba(148,163,184,0.4)] light:border-slate-300 text-slate-200 light:text-slate-800 hover:text-white light:hover:text-slate-950 hover:border-[rgba(148,163,184,0.6)] light:hover:border-slate-500 focus-visible:ring-2 focus-visible:ring-[rgba(129,140,248,0.25)] light:focus-visible:ring-[rgba(15,23,42,0.25)] bg-transparent transition-colors",
-        ghost: "text-slate-300 light:text-slate-700 hover:text-slate-100 light:hover:text-slate-950",
-        link: "text-slate-300 light:text-slate-700 underline-offset-4 hover:underline",
+          "border border-[var(--border-line)] bg-transparent text-[var(--graphite)] hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)]",
+        technical:
+          "border border-[var(--border-line)] bg-[var(--paper)] font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite)] hover:border-[var(--graphite)] hover:bg-[var(--surface-subtle)]",
+        ghost: "text-[var(--graphite-muted)] hover:text-[var(--graphite)] hover:bg-[var(--surface-subtle)]",
+        link: "text-[var(--graphite-muted)] underline-offset-4 hover:text-[var(--graphite)] hover:underline",
       },
       size: {
-        default: "px-3.5 py-1.5 text-sm",
+        default: "px-4 py-2 text-sm",
         sm: "px-3 py-1.5 text-xs",
-        lg: "px-5 py-2 text-base",
-        icon: "h-10 w-10 [&_svg]:size-5",
+        lg: "px-5 py-2.5 text-base",
+        icon: "h-10 w-10 p-0 [&_svg]:size-5",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-[var(--radius-sm)] border border-[var(--border-line)] bg-[var(--surface-raised)] text-[var(--graphite)] shadow-[var(--shadow-paper-xs)]",
       className
     )}
     {...props}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -87,7 +87,7 @@ const NavigationMenuViewport = React.forwardRef<
     <div className="absolute -top-1 right-0 left-0 h-1 bg-transparent pointer-events-none" />
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-right relative h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-lg border border-slate-800/70 bg-slate-900/95 backdrop-blur-sm text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-right relative h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border-line)] bg-[var(--paper)] text-[var(--graphite)] shadow-[var(--shadow-paper-sm)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className
       )}
       ref={ref}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -38,7 +38,7 @@ const SheetOverlay =
     ) => (
       <SheetPrimitive.Overlay
         className={cn(
-          "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "fixed inset-0 z-50 bg-[rgba(15,16,16,0.18)] backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           className,
         )}
         {...props}
@@ -53,17 +53,17 @@ SheetOverlay.displayName =
 
 const sheetVariants =
   cva(
-    "fixed z-50 gap-4 bg-slate-950 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+    "fixed z-50 gap-4 bg-[var(--paper)] p-6 text-[var(--graphite)] shadow-[var(--shadow-paper-sm)] transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
     {
       variants:
         {
           side: {
-            top: "inset-x-0 top-0 border-b border-slate-800/70 data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+            top: "inset-x-0 top-0 border-b border-[var(--border-line)] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
             bottom:
-              "inset-x-0 bottom-0 border-t border-slate-800/70 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-            left: "inset-y-0 left-0 h-full w-3/4 border-r border-slate-800/70 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+              "inset-x-0 bottom-0 border-t border-[var(--border-line)] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            left: "inset-y-0 left-0 h-full w-3/4 border-r border-[var(--border-line)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
             right:
-              "inset-y-0 right-0 h-full w-3/4 border-l border-slate-800/70 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+              "inset-y-0 right-0 h-full w-3/4 border-l border-[var(--border-line)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           },
         },
       defaultVariants:
@@ -116,7 +116,7 @@ const SheetContent =
           {
             children
           }
-          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-md p-1.5 bg-slate-800/80 text-slate-200 hover:bg-slate-700/90 hover:text-slate-100 ring-offset-background transition-all focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:pointer-events-none">
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-[var(--radius-sm)] border border-[var(--border-line)] bg-[var(--paper)] p-1.5 text-[var(--graphite-muted)] transition-all hover:border-[var(--border-strong)] hover:text-[var(--graphite)] focus:outline-none focus:ring-2 focus:ring-[var(--border-strong)] disabled:pointer-events-none">
             <X className="h-5 w-5" />
             <span className="sr-only">
               Close
@@ -182,7 +182,7 @@ const SheetTitle =
           ref
         }
         className={cn(
-          "text-lg font-semibold text-slate-50 leading-none tracking-tight",
+          "text-lg font-semibold text-[var(--graphite)] leading-none tracking-tight",
           className,
         )}
         {...props}
@@ -213,7 +213,7 @@ const SheetDescription =
           ref
         }
         className={cn(
-          "text-sm text-slate-400",
+          "text-sm text-[var(--graphite-muted)]",
           className,
         )}
         {...props}

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -25,11 +25,11 @@ export interface JourneyPhoto {
 
 export const aboutBio: AboutBio = {
   name: 'Naufaldi Rafif Satriya',
-  title: 'Product Engineer & Mentor',
-bioParagraphs: [
-    'I\'m a product engineer and mentor from Bekasi, Indonesia. I\'ve focused on building meaningful products from designs. I believe that code is a craft and mentorship is how we build a legacy.',
+  title: 'Software Engineer & Mentor',
+  bioParagraphs: [
+    'I\'m a software engineer and mentor from Bekasi, Indonesia. Frontend is my strongest foundation, and I\'m intentionally expanding into backend systems, architecture, and end-to-end product delivery.',
     'My purpose extends beyond coding. I find deep satisfaction in helping others grow, having mentored over 200 individuals and connected with a community of 14,000+ on Twitter. I enjoy hosting workshops and sessions, especially for the "aha" moments that lead to breakthroughs.',
-    'Balance is key. I\'m expanding my skills by learning backend development and, most importantly, learning to be a better partner. I believe great engineers are whole people, bringing curiosity and heart to everything they do.',
+    'Balance is key. I\'m growing from interface execution into broader software engineering, while learning to be a better partner. I believe great engineers are whole people, bringing curiosity and heart to everything they do.',
   ],
   profileImageUrl: 'https://res.cloudinary.com/cynux/image/upload/v1762848965/portfolio-2025/avatar.jpg',
   signature: 'Naufaldi',
@@ -134,4 +134,3 @@ export const techStack: TechStackItem[] = [
   { name: 'Node.js', iconName: 'Server' },
   { name: 'PostgreSQL', iconName: 'Database' },
 ]
-

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -110,12 +110,12 @@ export const workExperiences: WorkExperience[] = [
       'Converted Figma designs to pixel-perfect HTML/CSS code, facilitating rapid integration into Laravel framework',
       'Developed a dynamic Blog/Company Profile using ReactJS with backend API integration, enabling quick launch of feature-rich applications',
       'Built responsive websites optimized for various browsers, focusing on accessibility features like color contrast and ARIA labels',
-      'Mentored interns on frontend development practices, elevating their skills and contributing to team capacity growth',
+      'Mentored interns on web development practices, elevating their skills and contributing to team capacity growth',
     ],
     keyAchievementsMarkdown: `- Converted Figma designs to pixel-perfect HTML/CSS code, facilitating rapid integration into Laravel framework
 - Developed a dynamic Blog/Company Profile using ReactJS with backend API integration, enabling quick launch of feature-rich applications
 - Built responsive websites optimized for various browsers, focusing on accessibility features like color contrast and ARIA labels
-- Mentored interns on frontend development practices, elevating their skills and contributing to team capacity growth`,
+- Mentored interns on web development practices, elevating their skills and contributing to team capacity growth`,
     techStack: ['React', 'JavaScript', 'HTML', 'CSS', 'Laravel'],
   },
   {
@@ -130,12 +130,12 @@ export const workExperiences: WorkExperience[] = [
       'Developed a company landing page using component frameworks, delivering high-quality outcomes and accelerating prototyping',
       'Built a transaction management dashboard using HTML/CSS, optimized for Laravel integration and efficient transaction oversight',
       'Engineered internal tools for simplifying operational tasks, improving process efficiency',
-      'Mentored interns on frontend development practices, effectively managing and enriching their learning experience',
+      'Mentored interns on web development practices, effectively managing and enriching their learning experience',
     ],
     keyAchievementsMarkdown: `- Developed a company landing page using component frameworks, delivering high-quality outcomes and accelerating prototyping
 - Built a transaction management dashboard using HTML/CSS, optimized for Laravel integration and efficient transaction oversight
 - Engineered internal tools for simplifying operational tasks, improving process efficiency
-- Mentored interns on frontend development practices, effectively managing and enriching their learning experience`,
+- Mentored interns on web development practices, effectively managing and enriching their learning experience`,
     techStack: ['HTML', 'CSS', 'JavaScript', 'Laravel'],
   },
 ]
@@ -143,4 +143,3 @@ export const workExperiences: WorkExperience[] = [
 export const getLatestExperiences = (limit: number = 4): WorkExperience[] => {
   return workExperiences.slice(0, limit)
 }
-

--- a/src/data/mentorSpeaker.ts
+++ b/src/data/mentorSpeaker.ts
@@ -76,7 +76,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
     id: '11',
     eventName: 'Twitter Spaces',
-    brief: 'Hosting Twitter Spaces to engage with a global audience through real-time dialogue, sharing knowledge and insights about frontend development, career growth, and the tech industry.',
+    brief: 'Hosting Twitter Spaces to engage with a global audience through real-time dialogue, sharing knowledge and insights about software engineering, career growth, and the tech industry.',
     date: 'Ongoing',
     type: 'speaker',
     links: {
@@ -86,7 +86,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
     id: '5',
     eventName: 'ADPList Mentorship',
-    brief: 'Engaged as a mentor on ADPList, providing personalized 1:1 mentorship to emerging Frontend Engineers, focusing on career growth and technical skills enhancement. Recognized for outstanding impact, achieving Top 1% Mentor status consecutively in February, March, and April 2023.',
+    brief: 'Engaged as a mentor on ADPList, providing personalized 1:1 mentorship to emerging engineers, focusing on career growth and technical skills enhancement. Recognized for outstanding impact, achieving Top 1% Mentor status consecutively in February, March, and April 2023.',
     date: 'February 2023 - Present',
     type: 'mentoring',
     links: {
@@ -97,7 +97,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
     id: '6',
     eventName: 'Dibimbing Bootcamp',
-    brief: 'Mentored over 50 individuals in the \'Dibimbing\' bootcamp, focusing on Frontend Engineering with an emphasis on Web Development and the React Ecosystem, fostering a new generation of skilled developers.',
+    brief: 'Mentored over 50 individuals in the \'Dibimbing\' bootcamp, focusing on web development, React, and practical product-building skills for a new generation of developers.',
     date: 'June 2023 - January 2024',
     type: 'mentoring',
     links: {
@@ -119,7 +119,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
     id: '8',
     eventName: 'Ekskul Frontend Development',
-    brief: 'Taught and mentored over 30 mentees, providing comprehensive guidance in frontend development. Developed a detailed curriculum focusing on HTML, CSS, and JavaScript, aiming to build strong foundational skills.',
+    brief: 'Taught and mentored over 30 mentees, providing comprehensive guidance in web development. Developed a detailed curriculum focusing on HTML, CSS, and JavaScript, aiming to build strong foundational skills.',
     date: 'December 2021 - January 2022',
     type: 'mentoring',
     links: {
@@ -183,7 +183,7 @@ export const mentorSpeakerEngagements: MentorSpeakerItem[] = [
   {
     id: '17',
     eventName: 'Nest Academy',
-    brief: 'Frontend Engineer Mentor: built and delivered a structured HTML, CSS, and JavaScript curriculum, guided learners through projects with best practices, and provided ongoing technical support.',
+    brief: 'Software engineering mentor: built and delivered a structured HTML, CSS, and JavaScript curriculum, guided learners through projects with best practices, and provided ongoing technical support.',
     date: 'August 2022 – September 2022',
     type: 'mentoring',
     links: {
@@ -242,4 +242,3 @@ export const getAllOrganizations = (): string[] => {
   })
   return Array.from(organizations)
 }
-

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -33,8 +33,8 @@ export interface SiteConfig {
 
 export const siteConfig: SiteConfig = {
   name: 'Naufaldi Rafif S.',
-  tagline: 'Product Engineer & Mentor',
-  bio: 'Building frontend solutions with 7 years of experience. Mentored 200+ developers and transitioning towards fullstack while sharing knowledge through speaking and mentorship.',
+  tagline: 'Software Engineer & Mentor',
+  bio: 'Software engineer focused on product systems, with deep frontend experience and growing backend ownership.',
   statusBadge: 'Open to new projects',
   availability: 'Q4 • 2025 availability',
   heroImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1400&auto=format&fit=crop',
@@ -69,4 +69,3 @@ export const siteConfig: SiteConfig = {
     adplist: 'https://adplist.org/mentors/naufaldi-rafif-s',
   },
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -21,14 +21,10 @@
     "Segoe UI",
     sans-serif;
   --font-blog:
-    "Inter",
+    "Manrope",
     ui-sans-serif,
     system-ui,
-    sans-serif,
-    "Apple Color Emoji",
-    "Segoe UI Emoji",
-    "Segoe UI Symbol",
-    "Noto Color Emoji";
+    sans-serif;
 }
 
 /* Custom font utility classes */
@@ -61,6 +57,24 @@
 }
 
 :root {
+  --paper: #ffffff;
+  --paper-soft: #fafaf9;
+  --graphite: #0f1010;
+  --graphite-muted: #3a3a3c;
+  --line: #e3e5e8;
+  --line-soft: #f0f1f3;
+  --status-green: #22c55e;
+  --surface-base: var(--paper);
+  --surface-subtle: var(--paper-soft);
+  --surface-raised: #ffffff;
+  --border-line: var(--line);
+  --border-dashed: #d8dce0;
+  --border-strong: #b8c0c8;
+  --radius-none: 0;
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --shadow-paper-xs: 0 1px 2px rgba(15, 16, 16, 0.04);
+  --shadow-paper-sm: 0 8px 24px -18px rgba(15, 16, 16, 0.2);
   --background: 0
     0%
     100%;
@@ -88,6 +102,21 @@
 }
 
 .dark {
+  --paper: #090a0c;
+  --paper-soft: #101216;
+  --graphite: #f5f5f2;
+  --graphite-muted: #b7bbc1;
+  --line: #242830;
+  --line-soft: #171a20;
+  --status-green: #4ade80;
+  --surface-base: var(--paper);
+  --surface-subtle: var(--paper-soft);
+  --surface-raised: #11141a;
+  --border-line: var(--line);
+  --border-dashed: #343a44;
+  --border-strong: #4b5563;
+  --shadow-paper-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-paper-sm: 0 10px 28px -20px rgba(0, 0, 0, 0.8);
   --background: 222.2
     47.4%
     11.2%;
@@ -126,7 +155,12 @@ html {
 }
 
 body {
-  @apply bg-slate-900 text-slate-200 antialiased;
+  background: var(
+    --paper
+  );
+  color: var(
+    --graphite
+  );
   font-family: var(
     --font-body
   );
@@ -137,7 +171,12 @@ body {
 
 .light
   body {
-  @apply bg-white text-slate-900;
+  background: var(
+    --paper
+  );
+  color: var(
+    --graphite
+  );
 }
 
 ::selection {
@@ -180,6 +219,220 @@ body {
     15 23
       42
   );
+}
+
+.font-display {
+  font-family:
+    "Arial Narrow",
+    "Roboto Condensed",
+    "Helvetica Neue",
+    var(
+      --font-sans
+    );
+}
+
+.text-display-hero {
+  font-family:
+    "Arial Narrow",
+    "Roboto Condensed",
+    "Helvetica Neue",
+    var(
+      --font-sans
+    );
+  font-size: clamp(
+    4.25rem,
+    13.2vw,
+    11.25rem
+  );
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 0.82;
+  text-transform: uppercase;
+}
+
+.text-section-title {
+  font-family: var(
+    --font-mono
+  );
+  font-size: clamp(
+    2rem,
+    5vw,
+    4.75rem
+  );
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.text-body-readable {
+  color: var(
+    --graphite-muted
+  );
+  font-family: var(
+    --font-body
+  );
+  font-size: 1rem;
+  line-height: 1.75;
+  max-width: 65ch;
+}
+
+.text-meta,
+.mono-label,
+.text-drawing-label {
+  font-family: var(
+    --font-mono
+  );
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.text-meta {
+  color: var(
+    --graphite-muted
+  );
+  font-size: 0.75rem;
+}
+
+.text-drawing-label {
+  color: color-mix(
+    in srgb,
+    var(
+      --graphite-muted
+    )
+      72%,
+    transparent
+  );
+  font-size: 0.6875rem;
+}
+
+.drawing-sheet {
+  position: relative;
+  background-color: var(
+    --paper
+  );
+  background-image:
+    linear-gradient(
+      color-mix(
+          in srgb,
+          var(
+            --line-soft
+          )
+            38%,
+          transparent
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(
+          in srgb,
+          var(
+            --line-soft
+          )
+            38%,
+          transparent
+        )
+        1px,
+      transparent
+        1px
+    );
+  background-size: 40px
+    40px;
+}
+
+.drawing-grid {
+  background-image:
+    linear-gradient(
+      var(
+          --line-soft
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      var(
+          --line-soft
+        )
+        1px,
+      transparent
+        1px
+    );
+  background-size: 32px
+    32px;
+}
+
+.drawing-rail {
+  border-left: 1px
+    dashed
+    var(
+      --border-dashed
+    );
+  border-right: 1px
+    dashed
+    var(
+      --border-dashed
+    );
+}
+
+.viewport-frame {
+  border: 1px
+    dashed
+    var(
+      --border-dashed
+    );
+}
+
+.coordinate-label {
+  color: color-mix(
+    in srgb,
+    var(
+      --graphite-muted
+    )
+      48%,
+    transparent
+  );
+  font-family: var(
+    --font-mono
+  );
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+}
+
+.section-rule {
+  border-top: 1px
+    solid
+    var(
+      --border-line
+    );
+}
+
+.technical-divider {
+  border-color: var(
+    --border-line
+  );
+}
+
+.site-container {
+  width: 100%;
+  max-width: 1440px;
+  margin-inline: auto;
+  padding-inline: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .site-container {
+    padding-inline: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .site-container {
+    padding-inline: 3rem;
+  }
 }
 
 /* Custom scrollbar for TOC sidebar */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
-  <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+  <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
     <App />
   </ThemeProvider>
 )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,26 +7,22 @@ import FadeInUp from "@/components/common/FadeInUp";
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex flex-col relative">
-      <div
-        className="bg-pattern"
-        aria-hidden="true"
-      />
+    <div className="relative flex min-h-screen flex-col bg-[var(--paper)] text-[var(--graphite)]">
       <HeroSection />
       <FadeInUp>
-        <div className="mx-auto max-w-7xl px-6 w-full">
-          <div className="border-t border-slate-800/70 light:border-slate-200" />
+        <div className="site-container">
+          <div className="section-rule" />
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 py-6">
             <p
-              className="text-xs text-slate-400 light:text-slate-600 font-body font-medium"
+              className="text-meta"
             >
               Building with clarity, performance, and craft.
             </p>
             <a
               href="#projects"
-              className="inline-flex items-center gap-1.5 text-xs text-slate-400 light:text-slate-600 hover:text-slate-200 light:hover:text-slate-900 transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 rounded-sm font-body font-medium"
+              className="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]"
             >
-              Browsework
+              Browse work
               <ChevronRight className="h-3.5 w-3.5" />
             </a>
           </div>


### PR DESCRIPTION
## What Change

- Added reusable design-system components for the editorial technical language: drawing frames, metadata rows, technical labels, section headers, work rows, experience rows, and footer columns.
- Reworked the homepage hero into an editorial index layout with a stronger name masthead, route controls, viewport-style guide lines, and software-engineer branding.
- Updated homepage sections for Experience, Portfolio, Mentor/Speaker, CTA, and Footer to use thin dividers, technical labels, and shared layout tokens instead of card-heavy UI.
- Restyled navigation and shared UI primitives so buttons, sheets, cards, and nav menus align with the new light-first system.
- Updated site/about/experience/mentorship copy to position Naufaldi as a Software Engineer & Mentor with frontend depth and growing backend/product-system ownership.

## Why Change

- The previous homepage leaned more app-dashboard/front-end-specific, while the new direction needs a cleaner editorial identity and broader software-engineer branding.
- The redesign creates a reusable visual system that can support future homepage and section work without copying the Dharma reference too directly.
- The content now frames frontend experience as a strong foundation while presenting broader software engineering, product systems, backend foundations, and mentorship as the current brand.

## Impact

- **Affected areas:** Homepage hero, navigation, footer, CTA, Experience, Portfolio, Mentor/Speaker, shared UI primitives, design tokens, and profile copy data.
- **Breaking changes:** No.
- **Dependencies:** No new packages added.
- **Testing:** Ran `rtk bun run build`; build completed successfully. Existing Vite warnings remain for `src/components/ui/separator.tsx` sourcemap reporting and large chunks.