### PR TITLE
feat: redesign about page drawing sheet

### DIFF
--- a/src/components/about/AboutMeSection.tsx
+++ b/src/components/about/AboutMeSection.tsx
@@ -1,58 +1,80 @@
-import ProfilePicture from './ProfilePicture'
-import TechStack from './TechStack'
+import ProfilePicture from '@/components/about/ProfilePicture'
+import TechStack from '@/components/about/TechStack'
 import { aboutBio, techStack } from '@/data/about'
 import FadeInUp from '@/components/common/FadeInUp'
 
 export default function AboutMeSection() {
   return (
-    <section className="px-6 md:px-0 py-12 md:py-16" aria-labelledby="about-me-heading">
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-start md:items-center">
+    <section className="border-b border-[var(--border-line)] py-10 md:py-14" aria-labelledby="about-me-heading">
+      <div className="mb-6 flex items-center gap-3 text-drawing-label">
+        <span>03 // CURRENT_NODE</span>
+        <span className="hidden h-px flex-1 bg-[var(--border-line)] sm:block" />
+        <span className="hidden sm:inline">source:data/about.ts</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-px border border-[var(--border-line)] bg-[var(--border-line)] lg:grid-cols-[420px_minmax(0,1fr)]">
+        <div className="bg-[var(--paper)] p-5 sm:p-6 md:p-8">
           <FadeInUp delay={0.06}>
-            <div className="flex justify-center">
-              <ProfilePicture
-                imageUrl={aboutBio.profileImageUrl}
-                signature={aboutBio.signature}
-              />
-            </div>
+            <ProfilePicture
+              imageUrl={aboutBio.profileImageUrl}
+              signature={aboutBio.signature}
+            />
           </FadeInUp>
+        </div>
 
+        <div className="bg-[var(--paper)] p-5 sm:p-6 md:p-8">
           <FadeInUp delay={0.12}>
-            <div className="space-y-6">
-            <div className="space-y-2">
-              <h2
-                id="about-me-heading"
-                className="text-3xl md:text-4xl text-slate-100 light:text-slate-900 font-mono font-bold"
-              >
-                {aboutBio.name}
-              </h2>
-              <p
-                className="text-base md:text-lg text-slate-400 light:text-slate-600 font-body font-medium"
-              >
-                {aboutBio.title}
-              </p>
-            </div>
+            <div className="space-y-7">
+              <div className="flex flex-col gap-5 border-b border-[var(--border-line)] pb-6 md:flex-row md:items-end md:justify-between">
+                <div className="space-y-2">
+                  <p className="text-drawing-label">identity.record</p>
+                  <h2
+                    id="about-me-heading"
+                    className="font-mono text-3xl font-medium leading-tight text-[var(--graphite)] md:text-5xl"
+                  >
+                    {aboutBio.name}
+                  </h2>
+                  <p className="font-body text-base font-medium text-[var(--graphite-muted)] md:text-lg">
+                    {aboutBio.title}
+                  </p>
+                </div>
+                <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+                  <div>NODE: PERSONAL_PROFILE</div>
+                  <div>LOCATION: BEKASI</div>
+                  <div>STATUS: GROWING</div>
+                </div>
+              </div>
 
-            <div className="space-y-4">
-              {aboutBio.bioParagraphs.map((paragraph, index) => (
-                <p
-                  key={index}
-                  className="text-sm md:text-base text-slate-300 light:text-slate-700 leading-relaxed font-body font-normal"
-                >
-                  {paragraph}
+              <div className="space-y-5">
+                {aboutBio.bioParagraphs.map((paragraph, index) => (
+                  <div
+                    key={paragraph}
+                    className="grid gap-4 border-b border-dashed border-[var(--border-dashed)] pb-5 last:border-b-0 last:pb-0 md:grid-cols-[72px_minmax(0,1fr)]"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                      p_{String(index + 1).padStart(2, '0')}
+                    </span>
+                    <p className="font-body text-sm font-normal leading-7 text-[var(--graphite-muted)] md:text-base md:leading-8">
+                      {paragraph}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="border-t border-[var(--border-line)] pt-6">
+                <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-drawing-label">skill_graph</p>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--status-green)]">
+                    stack_ready
+                  </span>
+                </div>
+                <p className="mb-4 text-body-readable text-sm">
+                  Current favorite stack for product engineering and full-stack
+                  systems work.
                 </p>
-              ))}
+                <TechStack items={techStack} />
+              </div>
             </div>
-
-            <div className="pt-4">
-              <p
-                className="mb-4 text-sm text-slate-400 light:text-slate-600 font-body font-medium"
-              >
-                I am also a full-stack engineer, here are my current favorite tech stack:
-              </p>
-              <TechStack items={techStack} />
-            </div>
-          </div>
           </FadeInUp>
         </div>
       </div>

--- a/src/components/about/ExperiencesSection.tsx
+++ b/src/components/about/ExperiencesSection.tsx
@@ -1,29 +1,39 @@
-import { Briefcase } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import { workExperiences } from '@/data/experience'
 import FadeInUp from '@/components/common/FadeInUp'
 
 export default function ExperiencesSection() {
   return (
-    <section className="px-6 md:px-0 py-12 md:py-16 relative" aria-labelledby="experiences-heading">
-      <div className="bg-orbs-experiences" aria-hidden="true" />
-      <div className="mx-auto max-w-7xl sm:px-6 w-full relative z-10">
-        <div className="space-y-12">
-          <FadeInUp delay={0.06}>
-            <div className="flex flex-col items-center gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-200/70 bg-slate-900/60 light:bg-white/80">
-                <Briefcase className="h-6 w-6 text-slate-300 light:text-slate-700" />
+    <section className="py-10 md:py-14" aria-labelledby="experiences-heading">
+      <div className="space-y-8">
+        <FadeInUp delay={0.06}>
+          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_280px] md:items-end">
+            <div>
+              <div className="mb-4 flex items-center gap-3 text-drawing-label">
+                <span>06 // EXPERIENCE_TRACE</span>
+                <span className="hidden h-px w-20 bg-[var(--border-line)] sm:block" />
               </div>
               <h2
                 id="experiences-heading"
-                className="text-3xl md:text-4xl text-slate-100 light:text-slate-900 text-center font-mono font-bold"
+                className="text-section-title text-[var(--graphite)]"
               >
                 Experiences
               </h2>
             </div>
-          </FadeInUp>
+            <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+              <div>source: data/experience.ts</div>
+              <div>render: work_rows</div>
+              <div>records: {workExperiences.length}</div>
+            </div>
+          </div>
+        </FadeInUp>
 
-          <div className="space-y-8">
+        <div className="border border-[var(--border-line)] bg-[var(--paper)]">
+          <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
+            <span>work.history</span>
+            <span>status:published</span>
+          </div>
+          <div className="divide-y divide-[var(--border-line)]">
             {workExperiences.map((experience, index) => {
               const endDate =
                 experience.endDate === 'Present'
@@ -32,68 +42,89 @@ export default function ExperiencesSection() {
 
               return (
                 <FadeInUp key={experience.id} delay={0.12 + index * 0.1}>
-                  <div className="grid grid-cols-1 md:grid-cols-[1fr_4fr] gap-6 md:gap-12 rounded-xl p-4 -m-4 hover:bg-slate-900/30 light:hover:bg-slate-100/50 transition-all duration-200">
-                  <div className="md:pt-1">
-                    <p
-                      className="text-sm text-slate-400 light:text-slate-600 uppercase font-body font-medium"
-                    >
-                      {experience.startDate} — {endDate}
-                    </p>
-                  </div>
-
-                  <div className="space-y-3">
-                    <div className="space-y-1">
-                      <h3
-                        className="text-xl md:text-2xl text-slate-100 light:text-slate-900 font-mono font-bold"
-                      >
-                        {experience.role}
-                      </h3>
-                      <div className="flex items-center gap-2">
-                        {experience.logoUrl && (
-                          <div className="h-4 w-4 rounded bg-slate-700 light:bg-slate-300" aria-hidden="true" />
-                        )}
-                        <p
-                          className="text-base text-slate-300 light:text-slate-700 font-body font-medium"
-                        >
-                          {experience.companyName}
-                        </p>
+                  <article className="grid gap-px bg-[var(--border-line)] lg:grid-cols-[220px_minmax(0,1fr)]">
+                    <div className="bg-[var(--surface-subtle)] p-4 sm:p-5">
+                      <div className="mb-5 flex items-center justify-between gap-4">
+                        <span className="text-drawing-label">
+                          exp_{String(index + 1).padStart(2, '0')}
+                        </span>
+                        <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
                       </div>
+                      <p className="font-mono text-xs uppercase leading-6 tracking-[0.16em] text-[var(--graphite)]">
+                        {experience.startDate}
+                        <br />
+                        {endDate}
+                      </p>
+                      <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--graphite-muted)]">
+                        {experience.employmentType.replace('-', '_')}
+                      </p>
                     </div>
 
-                    <p className="text-sm md:text-base text-slate-400 light:text-slate-600 leading-relaxed">
-                      {experience.description}
-                    </p>
-
-                    {experience.keyAchievementsMarkdown && (
-                      <div className="pt-2">
-                        <ReactMarkdown
-                          components={{
-                            ul: ({ children }) => (
-                              <ul className="list-disc list-outside ml-6 space-y-2 text-sm text-slate-300 light:text-slate-700">
-                                {children}
-                              </ul>
-                            ),
-                            li: ({ children }) => (
-                              <li className="pl-2">{children}</li>
-                            ),
-                            strong: ({ children }) => (
-                              <strong className="font-semibold text-slate-200 light:text-slate-900">
-                                {children}
-                              </strong>
-                            ),
-                            p: ({ children }) => (
-                              <p className="text-sm text-slate-300 light:text-slate-700 leading-relaxed">
-                                {children}
-                              </p>
-                            ),
-                          }}
-                        >
-                          {experience.keyAchievementsMarkdown}
-                        </ReactMarkdown>
+                    <div className="bg-[var(--paper)] p-4 sm:p-5 md:p-6">
+                      <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_220px] md:items-start">
+                        <div className="space-y-2">
+                          <h3 className="font-mono text-xl font-medium leading-tight text-[var(--graphite)] md:text-2xl">
+                            {experience.role}
+                          </h3>
+                          <p className="font-body text-base font-medium text-[var(--graphite-muted)]">
+                            {experience.companyName}
+                          </p>
+                        </div>
+                        <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.18em] text-[var(--graphite-muted)]">
+                          <div>company: {experience.companyName}</div>
+                          <div>type: {experience.employmentType}</div>
+                          <div>state: shipped</div>
+                        </div>
                       </div>
-                    )}
-                  </div>
-                </div>
+
+                      <p className="mt-5 max-w-3xl font-body text-sm leading-7 text-[var(--graphite-muted)] md:text-base md:leading-8">
+                        {experience.description}
+                      </p>
+
+                      {experience.keyAchievementsMarkdown && (
+                        <div className="mt-5 border-l border-dashed border-[var(--border-dashed)] pl-4">
+                          <ReactMarkdown
+                            components={{
+                              ul: ({ children }) => (
+                                <ul className="m-0 list-none space-y-2 font-body text-sm leading-7 text-[var(--graphite-muted)]">
+                                  {children}
+                                </ul>
+                              ),
+                              li: ({ children }) => (
+                                <li className="grid gap-3 sm:grid-cols-[34px_minmax(0,1fr)]">
+                                  <span className="mt-3 h-px bg-[var(--border-line)]" aria-hidden="true" />
+                                  <span>{children}</span>
+                                </li>
+                              ),
+                              strong: ({ children }) => (
+                                <strong className="font-semibold text-[var(--graphite)]">
+                                  {children}
+                                </strong>
+                              ),
+                              p: ({ children }) => (
+                                <p className="font-body text-sm leading-7 text-[var(--graphite-muted)]">
+                                  {children}
+                                </p>
+                              ),
+                            }}
+                          >
+                            {experience.keyAchievementsMarkdown}
+                          </ReactMarkdown>
+                        </div>
+                      )}
+
+                      <div className="mt-6 flex flex-wrap items-center gap-2 border-t border-[var(--border-line)] pt-4">
+                        {experience.techStack.map((tech) => (
+                          <span
+                            key={tech}
+                            className="border border-[var(--border-line)] bg-[var(--paper)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--graphite-muted)]"
+                          >
+                            {tech}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </article>
                 </FadeInUp>
               )
             })}

--- a/src/components/about/JourneyPhotoMarquee.tsx
+++ b/src/components/about/JourneyPhotoMarquee.tsx
@@ -6,15 +6,35 @@ export default function JourneyPhotoMarquee() {
   const duplicatedPhotos = [...journeyPhotos, ...journeyPhotos]
 
   return (
-    <section className="px-6 md:px-0 py-12 md:py-16 overflow-hidden" aria-label="Journey photo gallery" role="region">
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <FadeInUp delay={0.12}>
+    <section className="overflow-hidden border-b border-[var(--border-line)] py-10 md:py-14" aria-label="Journey photo gallery" role="region">
+      <FadeInUp delay={0.12}>
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="mb-4 flex items-center gap-3 text-drawing-label">
+              <span>05 // INFLUENCE_LOG</span>
+              <span className="hidden h-px w-20 bg-[var(--border-line)] sm:block" />
+            </div>
+            <h2 className="text-section-title text-[var(--graphite)]">
+              Field Signals
+            </h2>
+          </div>
+          <div className="font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+            <div>source: cloudinary</div>
+            <div>render: media_strip</div>
+          </div>
+        </div>
+
+        <div className="border border-[var(--border-line)] bg-[var(--paper)]">
+          <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
+            <span>asset.collection</span>
+            <span>items:{journeyPhotos.length}</span>
+          </div>
           <div className="relative overflow-hidden marquee-container">
-            <div className="flex gap-6 animate-marquee whitespace-nowrap">
+            <div className="flex gap-px animate-marquee whitespace-nowrap bg-[var(--border-line)]">
               {duplicatedPhotos.map((photo, index) => (
-                <div
+                <figure
                   key={`${photo.id}-${index}`}
-                  className="flex-shrink-0 h-48 w-64 md:h-56 md:w-72 rounded-lg overflow-hidden grayscale light:grayscale-0 transition-all duration-300 opacity-90 border border-slate-800/40 light:border-slate-200/70 bg-slate-900/20 light:bg-white/70 hover:grayscale-0 hover:opacity-100 hover:scale-105"
+                  className="group relative h-48 w-64 flex-shrink-0 overflow-hidden bg-[var(--paper)] md:h-56 md:w-72"
                 >
                   <CloudinaryImg
                     publicId={photo.imageUrl}
@@ -23,13 +43,21 @@ export default function JourneyPhotoMarquee() {
                     alt={photo.alt}
                     noStyle
                     preview={false}
+                    imgClassName="object-cover grayscale transition duration-300 group-hover:grayscale-0 group-hover:scale-[1.03]"
                   />
-                </div>
+                  <figcaption className="absolute bottom-0 left-0 right-0 border-t border-[var(--border-line)] bg-[var(--paper)]/88 px-3 py-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[var(--graphite-muted)]">
+                    log_{String((index % journeyPhotos.length) + 1).padStart(2, '0')}
+                  </figcaption>
+                </figure>
               ))}
             </div>
           </div>
-        </FadeInUp>
-      </div>
+          <div className="flex items-center gap-2 border-t border-[var(--border-line)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--status-green)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
+            influence_log_ready
+          </div>
+        </div>
+      </FadeInUp>
     </section>
   )
 }

--- a/src/components/about/ProfilePicture.tsx
+++ b/src/components/about/ProfilePicture.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight } from 'lucide-react'
+import { ImageIcon } from 'lucide-react'
 import { cn } from '@/lib'
 import CloudinaryImg from '@/components/ui/cloudinary-img'
 
@@ -14,29 +14,25 @@ export default function ProfilePicture({
   className,
 }: ProfilePictureProps) {
   return (
-    <div className={cn('relative', className)}>
-      <div
-        className="absolute -left-6 top-4 opacity-20"
-        aria-hidden="true"
-        style={{
-          animation: 'fade-in 900ms ease-out both',
-          animationDelay: '60ms',
-        }}
-      >
-        <div className="flex items-center gap-2">
-          <div className="h-0.5 w-6 border-t border-dashed border-slate-600 light:border-slate-300" />
-          <ArrowRight className="h-3 w-3 text-slate-600 light:text-slate-400" />
-        </div>
+    <div className={cn('relative border border-[var(--border-line)] bg-[var(--paper)]', className)}>
+      <div className="flex items-center justify-between border-b border-[var(--border-line)] bg-[var(--surface-subtle)] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--graphite-muted)]">
+        <span className="inline-flex items-center gap-2">
+          <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          asset.profile
+        </span>
+        <span>render:image</span>
       </div>
-
-      <div
-        className="relative rotate-2 bg-white p-4 shadow-2xl w-[300px] md:w-auto light:shadow-slate-200/70 hover:shadow-[0_25px_50px_-12px_rgba(0,0,0,0.4)] hover:-rotate-1 transition-all duration-300"
-        style={{
-          animation: 'fade-in 900ms ease-out both',
-          animationDelay: '120ms',
-        }}
-      >
-        <div className="border-4 border-slate-900 light:border-slate-200 bg-white p-3">
+      <div className="relative p-4">
+        <div
+          className="pointer-events-none absolute inset-4"
+          aria-hidden="true"
+        >
+          <div className="absolute left-0 right-0 top-6 border-t border-dashed border-[var(--border-dashed)]" />
+          <div className="absolute bottom-6 left-0 right-0 border-t border-dashed border-[var(--border-dashed)]" />
+          <div className="absolute left-6 top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+          <div className="absolute right-6 top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+        </div>
+        <div className="relative bg-[var(--paper)] p-3">
           <CloudinaryImg
             publicId={imageUrl}
             width={600}
@@ -44,13 +40,23 @@ export default function ProfilePicture({
             alt="Profile photo of Naufaldi Rafif Satriya"
             preview={false}
             noStyle
-            className="w-full md:w-[300px]"
+            className="aspect-[3/4] w-full border border-[var(--border-line)]"
+            imgClassName="object-cover grayscale"
           />
         </div>
-        <div
-          className="mt-3 text-center text-sm italic text-slate-900 light:text-slate-700 font-[cursive] font-normal"
-        >
-          {signature}
+      </div>
+      <div className="grid grid-cols-2 gap-px border-t border-[var(--border-line)] bg-[var(--border-line)]">
+        <div className="bg-[var(--paper)] px-4 py-3">
+          <div className="text-drawing-label">Source</div>
+          <div className="mt-1 truncate font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite)]">
+            cloudinary
+          </div>
+        </div>
+        <div className="bg-[var(--paper)] px-4 py-3">
+          <div className="text-drawing-label">Signature</div>
+          <div className="mt-1 truncate font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite)]">
+            {signature}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/about/TechStack.tsx
+++ b/src/components/about/TechStack.tsx
@@ -26,25 +26,22 @@ const iconMap: Record<string, LucideIcon> = {
 
 export default function TechStack({ items, className }: TechStackProps) {
   return (
-    <div className={cn('flex flex-wrap items-center gap-4', className)}>
-      {items.map((item) => {
+    <div className={cn('grid grid-cols-2 gap-px border border-[var(--border-line)] bg-[var(--border-line)] sm:grid-cols-3', className)}>
+      {items.map((item, index) => {
         const Icon = iconMap[item.iconName] || Code
 
         return (
           <div
             key={item.name}
-            className="flex flex-col items-center gap-2"
-            style={{
-              animation: 'fade-in 900ms ease-out both',
-              animationDelay: `${120 + items.indexOf(item) * 50}ms`,
-            }}
+            className="group bg-[var(--paper)] px-3 py-3 transition-colors hover:bg-[var(--surface-subtle)]"
           >
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-200/70 bg-slate-900/60 light:bg-white/80 transition-all duration-200 hover:border-slate-600/80 light:hover:border-slate-300 hover:bg-slate-800/80 light:hover:bg-slate-50 hover:scale-110">
-              <Icon className="h-6 w-6 text-slate-300 light:text-slate-700" />
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--graphite-muted)]">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <Icon className="h-4 w-4 text-[var(--graphite-muted)] transition-colors group-hover:text-[var(--graphite)]" />
             </div>
-            <span
-              className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium"
-            >
+            <span className="font-mono text-xs font-medium uppercase tracking-[0.12em] text-[var(--graphite)]">
               {item.name}
             </span>
           </div>

--- a/src/components/about/WhatImUpToSection.tsx
+++ b/src/components/about/WhatImUpToSection.tsx
@@ -1,38 +1,55 @@
-import { Sparkles } from 'lucide-react'
 import { currentActivities } from '@/data/about'
 import FadeInUp from '@/components/common/FadeInUp'
 
 export default function WhatImUpToSection() {
   return (
-    <section className="px-6 md:px-0 py-12 md:py-16" aria-labelledby="what-im-up-to-heading">
-      <div className="mx-auto max-w-7xl sm:px-6 w-full">
-        <FadeInUp delay={0.18}>
-          <div className="rounded-2xl border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/85 p-6 md:p-8 shadow-lg light:shadow-slate-200/70 hover:border-slate-700/60 light:hover:border-slate-300 hover:shadow-lg hover:shadow-slate-900/20 light:hover:shadow-slate-200/30 transition-all duration-200">
-            <div className="mb-6 flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-200/70 bg-slate-800/60 light:bg-slate-100">
-                <Sparkles className="h-5 w-5 text-slate-300 light:text-slate-700" />
-              </div>
-              <h2
-                id="what-im-up-to-heading"
-                className="text-2xl md:text-3xl text-slate-100 light:text-slate-900 font-mono font-bold"
-              >
-                What I'm up to now
-              </h2>
+    <section className="border-b border-[var(--border-line)] py-10 md:py-14" aria-labelledby="what-im-up-to-heading">
+      <FadeInUp delay={0.18}>
+        <div className="mb-6 grid gap-5 md:grid-cols-[minmax(0,1fr)_260px] md:items-end">
+          <div>
+            <div className="mb-4 flex items-center gap-3 text-drawing-label">
+              <span>04 // CURRENT_ACTIVITY</span>
+              <span className="hidden h-px w-20 bg-[var(--border-line)] sm:block" />
             </div>
-
-            <ul className="list-disc list-outside ml-6 space-y-3 text-sm md:text-base text-slate-300 light:text-slate-700">
-              {currentActivities.map((activity, index) => (
-                <FadeInUp key={activity.id} delay={0.24 + index * 0.05}>
-                  <li className="pl-2">
-                    {activity.emoji && <span className="mr-2">{activity.emoji}</span>}
-                    {activity.text}
-                  </li>
-                </FadeInUp>
-              ))}
-            </ul>
+            <h2
+              id="what-im-up-to-heading"
+              className="text-section-title text-[var(--graphite)]"
+            >
+              Now Queue
+            </h2>
           </div>
-        </FadeInUp>
-      </div>
+          <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+            <div>ROUTE: /ABOUT</div>
+            <div>MODULE: CURRENT_NODE</div>
+            <div>STATUS: ACTIVE</div>
+          </div>
+        </div>
+
+        <div className="border border-[var(--border-line)] bg-[var(--paper)]">
+          <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
+            <span>source: profile_state</span>
+            <span>render: activity_rows</span>
+          </div>
+          <ul className="divide-y divide-[var(--border-line)]" aria-label="Current activity list">
+            {currentActivities.map((activity, index) => (
+              <FadeInUp key={activity.id} delay={0.24 + index * 0.05}>
+                <li className="grid gap-4 px-4 py-5 transition-colors hover:bg-[var(--surface-subtle)] sm:grid-cols-[88px_minmax(0,1fr)_140px] sm:items-center">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                    node_{String(index + 1).padStart(2, '0')}
+                  </span>
+                  <p className="font-body text-sm font-medium leading-7 text-[var(--graphite-muted)] md:text-base">
+                    {activity.text}
+                  </p>
+                  <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--status-green)]">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
+                    active
+                  </span>
+                </li>
+              </FadeInUp>
+            ))}
+          </ul>
+        </div>
+      </FadeInUp>
     </section>
   )
 }

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -9,7 +9,6 @@ export interface AboutBio {
 export interface CurrentActivity {
   id: string
   text: string
-  emoji?: string
 }
 
 export interface TechStackItem {
@@ -39,22 +38,18 @@ export const currentActivities: CurrentActivity[] = [
   {
     id: '1',
     text: 'Planting seeds of influence, one tweet and post at a time',
-    emoji: '🌱',
   },
   {
     id: '2',
     text: 'Crafting impact that ripples through the company',
-    emoji: '💫',
   },
   {
     id: '3',
     text: 'Diving deep into backend realms, expanding my horizons',
-    emoji: '🚀',
   },
   {
     id: '4',
     text: 'Learning the art of partnership, one day at a time',
-    emoji: '💕',
   },
 ]
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,32 +1,243 @@
-import { User } from 'lucide-react'
+import { GitBranch, MapPin, Network, UserRound, UsersRound } from 'lucide-react'
 import AboutMeSection from '@/components/about/AboutMeSection'
 import WhatImUpToSection from '@/components/about/WhatImUpToSection'
 import ExperiencesSection from '@/components/about/ExperiencesSection'
 import JourneyPhotoMarquee from '@/components/about/JourneyPhotoMarquee'
 import FadeInUp from '@/components/common/FadeInUp'
+import { aboutBio } from '@/data/about'
+
+const profileSignals = [
+  {
+    label: 'Role',
+    value: aboutBio.title,
+  },
+  {
+    label: 'Location',
+    value: 'Bekasi, Indonesia',
+  },
+  {
+    label: 'Mentorship',
+    value: '200+ people',
+  },
+  {
+    label: 'Community',
+    value: '14,000+ reach',
+  },
+]
+
+function ProfileSystemGraph() {
+  return (
+    <svg
+      viewBox="0 0 320 260"
+      role="img"
+      aria-labelledby="about-graph-title about-graph-desc"
+      className="h-full w-full text-[var(--graphite-muted)]"
+    >
+      <title id="about-graph-title">About page profile system graph</title>
+      <desc id="about-graph-desc">
+        Identity, work, mentorship, location, and learning nodes connected into
+        the about page interface.
+      </desc>
+      <rect
+        x="28"
+        y="28"
+        width="264"
+        height="204"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <path
+        d="M58 72H262M58 132H262M58 192H262M94 48V212M160 48V212M226 48V212"
+        stroke="var(--border-dashed)"
+        strokeDasharray="4 6"
+      />
+      <path
+        d="M94 132H160M160 132H226M160 132V72M160 132V192"
+        stroke="var(--border-line)"
+      />
+      <g className="font-mono text-[10px] uppercase tracking-[0.18em]">
+        <rect
+          x="58"
+          y="112"
+          width="72"
+          height="40"
+          fill="var(--paper)"
+          stroke="var(--border-line)"
+        />
+        <text x="94" y="136" textAnchor="middle" fill="currentColor">
+          ID
+        </text>
+        <rect
+          x="124"
+          y="52"
+          width="72"
+          height="40"
+          fill="var(--paper)"
+          stroke="var(--border-line)"
+        />
+        <text x="160" y="76" textAnchor="middle" fill="currentColor">
+          WORK
+        </text>
+        <rect
+          x="190"
+          y="112"
+          width="72"
+          height="40"
+          fill="var(--paper)"
+          stroke="var(--border-line)"
+        />
+        <text x="226" y="136" textAnchor="middle" fill="currentColor">
+          MENTOR
+        </text>
+        <rect
+          x="124"
+          y="172"
+          width="72"
+          height="40"
+          fill="var(--paper)"
+          stroke="var(--border-line)"
+        />
+        <text x="160" y="196" textAnchor="middle" fill="var(--status-green)">
+          GROW
+        </text>
+      </g>
+      <circle cx="160" cy="132" r="5" fill="var(--status-green)" />
+    </svg>
+  )
+}
 
 export default function About() {
   return (
-    <div className="min-h-screen flex flex-col relative bg-slate-950 light:bg-slate-50">
-      <div className="bg-pattern-about" aria-hidden="true" />
-      <div className="mx-auto max-w-7xl sm:px-6 w-full py-20 md:py-16 relative z-10">
+    <div className="drawing-sheet relative min-h-screen bg-[var(--paper)]">
+      <div className="site-container relative z-10 w-full py-10 md:py-14">
         <FadeInUp delay={0.06}>
-          <div className="px-6 md:px-0 flex flex-col items-center gap-4 mb-12">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-200/70 bg-slate-900/60 light:bg-white/80 hover:border-slate-600/80 hover:bg-slate-800/80 light:hover:border-slate-300 light:hover:bg-slate-50 transition-colors">
-              <User className="h-6 w-6 text-slate-300 light:text-slate-700" />
+          <header className="relative overflow-hidden border border-[var(--border-line)] bg-[var(--paper)]/82 shadow-[var(--shadow-paper-xs)]">
+            <div
+              className="pointer-events-none absolute inset-0 hidden lg:block"
+              aria-hidden="true"
+            >
+              <div className="absolute left-8 right-8 top-10 border-t border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-8 right-8 bottom-10 border-t border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-[36%] top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-[68%] top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-8 top-10 h-px w-40 bg-[var(--status-green)]" />
+              <span className="coordinate-label absolute left-[36%] top-6 -translate-x-1/2">
+                CURRENT_NODE
+              </span>
+              <span className="coordinate-label absolute left-[68%] top-6 -translate-x-1/2">
+                PROFILE_GRAPH
+              </span>
             </div>
-            <h1
-              className="text-4xl md:text-5xl text-center font-mono font-bold"
-            >
-              <span className="text-slate-100 light:text-slate-900">About </span>
-              <span className="text-slate-300 light:text-slate-600">Me</span>
-            </h1>
-            <p
-              className="text-sm md:text-base text-slate-500 light:text-slate-600 text-center font-body font-medium"
-            >
-              A story of growth and discovery
-            </p>
-          </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]">
+              <div className="relative px-5 py-10 sm:px-6 md:px-8 md:py-14 lg:pr-14">
+                <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+                  <div className="flex items-center gap-3 text-drawing-label">
+                    <span>01 // IDENTITY</span>
+                    <span className="hidden h-px w-16 bg-[var(--border-line)] sm:block" />
+                  </div>
+                  <div className="hidden gap-6 text-drawing-label sm:flex">
+                    <span>src/pages/About.tsx</span>
+                    <span>route:/about</span>
+                  </div>
+                </div>
+
+                <div className="relative isolate max-w-4xl overflow-hidden border border-[var(--border-line)] bg-[var(--paper)] px-4 py-5 sm:px-6 md:px-7">
+                  <div
+                    className="pointer-events-none absolute inset-0 z-0 hidden sm:block"
+                    aria-hidden="true"
+                  >
+                    <div className="absolute left-[8%] right-[8%] top-[50%] border-t border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute left-[48%] top-[12%] bottom-[12%] border-l border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute right-5 top-5 border border-[var(--border-line)] bg-[var(--paper)]/76 p-2 font-mono text-[9px] uppercase leading-5 tracking-[0.16em] text-[var(--graphite-muted)]">
+                      <div>GET /about</div>
+                      <div>DATA - TSX</div>
+                      <div>VITE OK</div>
+                    </div>
+                    <div className="absolute right-12 bottom-5 grid grid-cols-3 gap-1">
+                      <span className="h-2 w-2 bg-[var(--status-green)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--status-green)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                    </div>
+                  </div>
+                  <h1 className="relative z-10 inline-block bg-[var(--paper)] pr-5 font-mono text-[44px] font-medium leading-[0.98] tracking-normal text-[var(--graphite)] sm:text-[72px] md:text-[96px]">
+                    About
+                    <br />
+                    Me
+                  </h1>
+                </div>
+
+                <div className="mt-7 grid gap-5 md:grid-cols-[minmax(0,1fr)_220px] md:items-end">
+                  <p className="text-body-readable text-base font-medium md:text-lg">
+                    A personal system profile: engineering foundations,
+                    mentorship signal, community influence, and the current
+                    direction from frontend execution toward broader product
+                    delivery.
+                  </p>
+                  <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+                    <div>ROUTE: /ABOUT</div>
+                    <div>SOURCE: PROFILE_DATA</div>
+                    <div>RENDER: IDENTITY_MAP</div>
+                  </div>
+                </div>
+              </div>
+
+              <aside className="border-t border-[var(--border-line)] px-5 py-8 sm:px-6 lg:border-l lg:border-t-0 lg:px-8 lg:py-12">
+                <div className="mb-9 flex items-center justify-between gap-4 text-drawing-label">
+                  <span>02 // BUILD_META</span>
+                  <span>BUILD:2026</span>
+                </div>
+
+                <dl className="grid grid-cols-2 gap-px border border-[var(--border-line)] bg-[var(--border-line)]">
+                  {profileSignals.map((signal) => (
+                    <div key={signal.label} className="bg-[var(--paper)] px-4 py-5">
+                      <dt className="text-drawing-label">{signal.label}</dt>
+                      <dd className="mt-2 font-mono text-sm uppercase tracking-[0.12em] text-[var(--graphite)]">
+                        {signal.value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+
+                <div className="mt-7 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--status-green)]">
+                  <span className="h-2 w-2 rounded-full bg-[var(--status-green)]" />
+                  <span>PROFILE_READY</span>
+                </div>
+
+                <div className="mt-10 hidden border border-dashed border-[var(--border-dashed)] p-4 lg:block">
+                  <div className="mb-4 flex items-center justify-between gap-4 text-drawing-label">
+                    <span>Profile graph</span>
+                    <Network className="h-3.5 w-3.5" aria-hidden="true" />
+                  </div>
+                  <div className="aspect-[1.23] overflow-hidden">
+                    <ProfileSystemGraph />
+                  </div>
+                </div>
+
+                <div className="mt-8 grid gap-3 border-t border-[var(--border-line)] pt-5 font-mono text-[10px] uppercase leading-6 tracking-[0.18em] text-[var(--graphite-muted)]">
+                  <div className="flex items-center gap-2">
+                    <UserRound className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>{aboutBio.name}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>Bekasi, Indonesia</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <UsersRound className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>Mentor route active</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <GitBranch className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>Branch: broader_engineering</span>
+                  </div>
+                </div>
+              </aside>
+            </div>
+          </header>
         </FadeInUp>
 
         <AboutMeSection />


### PR DESCRIPTION
## What Change

- Rebuilt `/about` around the drawing-sheet visual system with route labels, build metadata, profile signals, and a small profile graph.
- Restyled the identity/profile section into bordered technical modules using existing design tokens and the real profile image.
- Converted current activity content from emoji bullets into indexed module rows with status indicators.
- Restyled the journey photo strip as an `INFLUENCE_LOG` media module while preserving the marquee behavior.
- Reworked experience content into line-based work rows with date rails, metadata, achievement traces, and stack tags.
- Removed the unused emoji field from About activity data.

## Why Change

- The About page still used the older slate/orb/rounded-card visual language while Home and Blog had moved to the `faldi.xyz` drawing-sheet system.
- This aligns About with the current design direction from `docs/design.md`: paper background, thin borders, dashed rails, mono labels, route/build metadata, and status-green accent.
- The new layout keeps the same content but presents it as software-system modules so the page feels consistent with Home and Blog.

## Impact

- **Affected areas:** `/about`, About page components, and About activity data.
- **Breaking changes:** No. Public routes, content sources, and component APIs remain internal to this page.
- **Dependencies:** No new packages, schema changes, API changes, or environment changes.
- **Testing:** Ran `bun run build`; inspected `/about` desktop and mobile screenshots against the Home/Blog drawing-sheet style for wrapping, spacing, image rendering, and readable rails.