### PR TITLE
feat: redesign blog listing

### DIFF
--- a/src/components/blogs/BlogCard.tsx
+++ b/src/components/blogs/BlogCard.tsx
@@ -1,204 +1,174 @@
-import { useEffect, useState } from 'react'
-import { ArrowRight, Calendar, Clock, Eye, Heart } from 'lucide-react'
-import { Link, useNavigate } from 'react-router'
-import { Card } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { getBlogViews, getBlogLikes } from '@/lib/blogStorage'
-import type { BlogItem } from '@/data/blogs'
-import { cn } from '@/lib'
+import { useEffect, useState, type MouseEvent } from "react";
+import { ArrowRight, Calendar, Clock, Eye, Heart } from "lucide-react";
+import { Link, useNavigate } from "react-router";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getBlogLikes, getBlogViews } from "@/lib/blogStorage";
+import type { BlogItem } from "@/data/blogs";
+import { cn } from "@/lib";
 
 interface BlogCardProps {
-  blog: BlogItem
-  index: number
+  blog: BlogItem;
+  index: number;
 }
 
-export default function BlogCard({ blog, index }: BlogCardProps) {
-  const navigate = useNavigate()
-  const [views, setViews] = useState(0)
-  const [likes, setLikes] = useState(0)
-  const [imgError, setImgError] = useState(false)
-  const animationDelay = `${60 + index * 50}ms`
+const formatDate = (dateString: string) =>
+  new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    // Don't navigate if user clicked the title link itself or is selecting text
-    if ((e.target as HTMLElement).closest('a')) return
-    navigate(`/blogs/${blog.slug}`)
-  }
+const formatRoute = (category: string) => category.toUpperCase().replace(/\s+/g, "_");
+
+export default function BlogCard({ blog, index }: BlogCardProps) {
+  const navigate = useNavigate();
+  const [views, setViews] = useState(0);
+  const [likes, setLikes] = useState(0);
+  const [imgError, setImgError] = useState(false);
+  const animationDelay = `${80 + (index % 10) * 40}ms`;
+  const hasImage = Boolean(blog.image);
+  const imageOnRight = index % 2 === 0;
+
+  const handleCardClick = (event: MouseEvent<HTMLElement>) => {
+    if ((event.target as HTMLElement).closest("a")) {
+      return;
+    }
+
+    navigate(`/blogs/${blog.slug}`);
+  };
 
   useEffect(() => {
-    getBlogViews(blog.slug).then(setViews)
-    getBlogLikes(blog.slug).then(setLikes)
-  }, [blog.slug])
+    getBlogViews(blog.slug).then(setViews);
+    getBlogLikes(blog.slug).then(setLikes);
+  }, [blog.slug]);
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    })
-  }
+  const imagePreview = hasImage ? (
+    <div
+      className={cn(
+        "relative min-h-[180px] overflow-hidden border border-slate-800/70 bg-slate-900 light:border-[#e3e5e8] light:bg-[#f1f3f4] md:min-h-[220px]",
+        imageOnRight ? "lg:order-3" : "lg:order-1"
+      )}
+    >
+      <div className="absolute left-3 top-3 z-[1] border border-slate-700/70 bg-slate-950/80 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.2em] text-slate-300 light:border-[#d7dbe0] light:bg-white/85 light:text-[#5b5f66]">
+        Preview
+      </div>
+      {imgError ? (
+        <div className="flex h-full min-h-[180px] items-center justify-center px-5 text-center md:min-h-[220px]">
+          <span className="font-mono text-xs uppercase tracking-[0.18em] text-slate-500 light:text-[#8c929b]">
+            {blog.title}
+          </span>
+        </div>
+      ) : (
+        <img
+          src={blog.image}
+          alt={blog.title}
+          className="h-full min-h-[180px] w-full object-cover opacity-90 grayscale transition duration-300 group-hover:scale-[1.02] group-hover:opacity-100 group-hover:grayscale-0 md:min-h-[220px]"
+          loading="lazy"
+          decoding="async"
+          onError={() => setImgError(true)}
+        />
+      )}
+    </div>
+  ) : null;
 
   return (
-    <Card
+    <article
       role="article"
       aria-label={blog.title}
       onClick={handleCardClick}
-      className={cn(
-        'group cursor-pointer border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60 transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-300/70 hover:bg-slate-900/90 light:hover:bg-white/90 overflow-hidden',
-      )}
+      className="group grid cursor-pointer grid-cols-1 border-t border-slate-800/70 light:border-[#e3e5e8] lg:grid-cols-[170px_minmax(0,1fr)]"
       style={{
-        animation: 'fade-in 400ms ease-out both',
+        animation: "fade-in 420ms ease-out both",
         animationDelay,
       }}
     >
-      <div className="flex flex-col md:flex-row gap-4 p-4 md:p-6">
-        {blog.image && (
-          <div className="relative w-full md:w-48 lg:w-64 flex-shrink-0 h-48 md:h-40 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-800/40 light:bg-slate-100/60">
-            {imgError ? (
-              <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
-                <span
-                  className="text-center text-xs text-slate-400 light:text-slate-500 line-clamp-3"
-                  style={{ fontFamily: 'var(--font-body)', fontWeight: 500 }}
-                >
-                  {blog.title}
-                </span>
-              </div>
-            ) : (
-              <img
-                src={blog.image}
-                alt={blog.title}
-                className="h-full w-full object-cover"
-                loading="lazy"
-                decoding="async"
-                onError={() => setImgError(true)}
-              />
-            )}
-          </div>
+      <div className="border-b border-slate-800/70 py-5 font-mono text-[11px] uppercase tracking-[0.24em] text-slate-500 light:border-[#e3e5e8] light:text-[#8c929b] lg:border-b-0 lg:py-8 lg:pr-8">
+        {String(index + 1).padStart(2, "0")} // ENTRY
+      </div>
+
+      <div
+        className={cn(
+          "grid gap-5 py-6 transition-colors duration-200 group-hover:bg-slate-900/40 light:group-hover:bg-white/75 md:py-8 lg:px-7",
+          hasImage ? "lg:grid-cols-[minmax(0,1fr)_320px]" : "lg:grid-cols-1"
         )}
-        <div className="flex-1 space-y-3">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1 space-y-2">
-              <div className="flex items-center gap-2">
-                <Badge
-                  variant="outline"
-                  className="border-slate-700/70 light:border-slate-200/70 bg-slate-900/40 light:bg-white/40 text-slate-400 light:text-slate-600"
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontWeight: 500,
-                  }}
-                >
-                  {blog.category}
-                </Badge>
-              </div>
-              <h3
-                className="text-lg md:text-xl"
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontWeight: 600,
-                }}
-              >
-                <Link
-                  to={`/blogs/${blog.slug}`}
-                  className="text-slate-300 light:text-slate-800 hover:text-slate-100 light:hover:text-slate-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 rounded-sm"
-                >
-                  {blog.title}
-                </Link>
-              </h3>
-              <p
-                className="text-sm line-clamp-2 text-slate-300 light:text-slate-600"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontWeight: 400,
-                }}
-              >
-                {blog.description}
-              </p>
-            </div>
+      >
+        {!imageOnRight && imagePreview}
+
+        <div
+          className={cn(
+            "min-w-0 space-y-5",
+            hasImage && (imageOnRight ? "lg:order-1" : "lg:order-2")
+          )}
+        >
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500 light:text-[#8c929b]">
+            <span className="inline-flex items-center gap-2 text-[#22c55e]">
+              <span className="h-1.5 w-1.5 rounded-full bg-[#22c55e]" />
+              {formatRoute(blog.category)}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+              {formatDate(blog.date)}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              {blog.readTime || 5} min read
+            </span>
           </div>
 
-          <div className="flex items-center gap-3 pt-2">
-            <Avatar className="h-8 w-8 border border-slate-800/70 light:border-slate-200/70">
-              <AvatarImage src={blog.author.avatar} alt={blog.author.name} />
-              <AvatarFallback className="bg-slate-800 light:bg-slate-200 text-slate-300 light:text-slate-700 text-xs">
-                {blog.author.name.charAt(0).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex-1 flex flex-wrap items-center gap-3 text-xs text-slate-300 light:text-slate-600">
-              <span
-                className="text-slate-200 light:text-slate-800"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontWeight: 500,
-                }}
+          <div className="space-y-3">
+            <h2 className="max-w-4xl font-mono text-2xl leading-tight tracking-tight text-slate-100 light:text-[#111214] md:text-3xl">
+              <Link
+                to={`/blogs/${blog.slug}`}
+                className="rounded-sm transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:hover:text-[#111214] light:focus-visible:ring-slate-900/30"
               >
-                {blog.author.name}
-              </span>
-              <div className="flex items-center gap-1" aria-label={`Published ${formatDate(blog.date)}`}>
-                <Calendar className="h-3 w-3" aria-hidden="true" />
-                <span
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontWeight: 400,
-                  }}
-                >
-                  {formatDate(blog.date)}
-                </span>
-              </div>
-              <div className="flex items-center gap-1" aria-label={`${blog.readTime || 5} minute read`}>
-                <Clock className="h-3 w-3" aria-hidden="true" />
-                <span
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontWeight: 400,
-                  }}
-                >
-                  {blog.readTime || 5} min read
-                </span>
-              </div>
-              <div className="flex items-center gap-1" aria-label={`${views.toLocaleString()} views`}>
-                <Eye className="h-3 w-3" aria-hidden="true" />
-                <span
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontWeight: 400,
-                  }}
-                >
-                  {views.toLocaleString()} <span className="sr-only">views</span>
-                </span>
-              </div>
-              <div className="flex items-center gap-1" aria-label={`${likes.toLocaleString()} likes`}>
-                <Heart className="h-3 w-3" aria-hidden="true" />
-                <span
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontWeight: 400,
-                  }}
-                >
-                  {likes.toLocaleString()} <span className="sr-only">likes</span>
-                </span>
-              </div>
-            </div>
+                {blog.title}
+              </Link>
+            </h2>
+
+            <p className="max-w-4xl font-body text-sm font-medium leading-7 text-slate-400 light:text-[#5b5f66] md:text-base">
+              {blog.description}
+            </p>
           </div>
 
-          <div className="pt-2">
+          <div className="flex flex-col gap-4 border-t border-slate-800/70 pt-5 light:border-[#e3e5e8] sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-8 w-8 rounded-full border border-slate-800/70 light:border-[#e3e5e8]">
+                <AvatarImage src={blog.author.avatar} alt={blog.author.name} />
+                <AvatarFallback className="bg-slate-900 font-mono text-xs text-slate-300 light:bg-[#f1f3f4] light:text-[#5b5f66]">
+                  {blog.author.name.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <div className="font-body text-sm font-semibold text-slate-200 light:text-[#111214]">
+                  {blog.author.name}
+                </div>
+                <div className="mt-0.5 flex items-center gap-3 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 light:text-[#8c929b]">
+                  <span className="inline-flex items-center gap-1" aria-label={`${views.toLocaleString()} views`}>
+                    <Eye className="h-3 w-3" aria-hidden="true" />
+                    {views.toLocaleString()}
+                  </span>
+                  <span className="inline-flex items-center gap-1" aria-label={`${likes.toLocaleString()} likes`}>
+                    <Heart className="h-3 w-3" aria-hidden="true" />
+                    {likes.toLocaleString()}
+                  </span>
+                </div>
+              </div>
+            </div>
+
             <Link
               to={`/blogs/${blog.slug}`}
               tabIndex={-1}
               aria-hidden="true"
-              className="inline-flex items-center gap-1 text-sm text-slate-400 light:text-slate-500 transition-colors group-hover:text-slate-200 light:group-hover:text-slate-800"
-              style={{
-                fontFamily: 'var(--font-body)',
-                fontWeight: 500,
-              }}
+              className="inline-flex w-fit items-center gap-2 border border-slate-800/70 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-300 transition-colors group-hover:border-slate-700 group-hover:text-slate-100 light:border-[#e3e5e8] light:text-[#5b5f66] light:group-hover:border-[#bfc5cc] light:group-hover:text-[#111214]"
             >
-              Read more
-              <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+              Read
+              <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
             </Link>
           </div>
         </div>
-      </div>
-    </Card>
-  )
-}
 
+        {imageOnRight && imagePreview}
+      </div>
+    </article>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -741,7 +741,7 @@ body {
   background-position: center;
 }
 
-/* Background pattern for Blogs page - GPU-friendly single layer */
+/* Background pattern for Blogs page - technical drawing surface */
 .blog-pattern {
   position: relative;
   isolation: isolate;
@@ -768,90 +768,302 @@ body {
 
 .blog-pattern::before {
   background-image:
-    url("data:image/svg+xml,%3Csvg%20width%3D%27240%27%20height%3D%27240%27%20viewBox%3D%270%200%20240%20240%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%3E%3Crect%20width%3D%27240%27%20height%3D%27240%27%20fill%3D%27none%27/%3E%3Cpath%20d%3D%27M0%20120h240M120%200v240%27%20stroke%3D%27%2364748b%27%20stroke-opacity%3D%270.25%27%20stroke-width%3D%270.7%27/%3E%3Cpath%20d%3D%27M0%2060h240M0%20180h240M60%200v240M180%200v240%27%20stroke%3D%27%2364748b%27%20stroke-opacity%3D%270.12%27%20stroke-width%3D%270.5%27/%3E%3C/svg%3E"),
-    radial-gradient(
-      1200px
-        700px
-        at
-        15%
-        0%,
+    linear-gradient(
       rgba(
-        56,
-        189,
-        248,
-        0.12
-      ),
+          148,
+          163,
+          184,
+          0.13
+        )
+        1px,
       transparent
-        70%
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(
+          148,
+          163,
+          184,
+          0.13
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      rgba(
+          148,
+          163,
+          184,
+          0.07
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(
+          148,
+          163,
+          184,
+          0.07
+        )
+        1px,
+      transparent
+        1px
     );
   background-size:
     240px
       240px,
-    100%
-      100%;
-  background-position: center;
-  opacity: 0.9;
+    240px
+      240px,
+    48px
+      48px,
+    48px
+      48px;
+  background-position:
+    center
+      top,
+    center
+      top,
+    center
+      top,
+    center
+      top;
+  opacity: 0.55;
 }
 
 .blog-pattern::after {
-  background-image: radial-gradient(
-    900px
-      600px
-      at
-      85%
-      20%,
-    rgba(
-      139,
-      92,
-      246,
-      0.14
+  background-image:
+    linear-gradient(
+      to
+        right,
+      transparent
+        calc(
+          50% -
+            640px
+        ),
+      rgba(
+          148,
+          163,
+          184,
+          0.2
+        )
+        calc(
+          50% -
+            640px
+        ),
+      rgba(
+          148,
+          163,
+          184,
+          0.2
+        )
+        calc(
+          50% -
+            639px
+        ),
+      transparent
+        calc(
+          50% -
+            639px
+        ),
+      transparent
+        calc(
+          50% +
+            639px
+        ),
+      rgba(
+          148,
+          163,
+          184,
+          0.2
+        )
+        calc(
+          50% +
+            639px
+        ),
+      rgba(
+          148,
+          163,
+          184,
+          0.2
+        )
+        calc(
+          50% +
+            640px
+        ),
+      transparent
+        calc(
+          50% +
+            640px
+        )
     ),
-    transparent
-      75%
-  );
-  opacity: 0.4;
+    linear-gradient(
+      to
+        bottom,
+      rgba(
+          2,
+          6,
+          23,
+          0.16
+        ),
+      transparent
+        28%,
+      transparent
+        72%,
+      rgba(
+          2,
+          6,
+          23,
+          0.2
+        )
+    );
+  opacity: 0.9;
 }
 
 .light
   .blog-pattern::before {
   background-image:
-    url("data:image/svg+xml,%3Csvg%20width%3D%27240%27%20height%3D%27240%27%20viewBox%3D%270%200%20240%20240%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%3E%3Crect%20width%3D%27240%27%20height%3D%27240%27%20fill%3D%27none%27/%3E%3Cpath%20d%3D%27M0%20120h240M120%200v240%27%20stroke%3D%27%2394a3b8%27%20stroke-opacity%3D%270.35%27%20stroke-width%3D%270.7%27/%3E%3Cpath%20d%3D%27M0%2060h240M0%20180h240M60%200v240M180%200v240%27%20stroke%3D%27%2394a3b8%27%20stroke-opacity%3D%270.18%27%20stroke-width%3D%270.5%27/%3E%3C/svg%3E"),
-    radial-gradient(
-      1200px
-        700px
-        at
-        15%
-        0%,
+    linear-gradient(
       rgba(
-        14,
-        165,
-        233,
-        0.1
-      ),
+          203,
+          210,
+          219,
+          0.7
+        )
+        1px,
       transparent
-        70%
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(
+          203,
+          210,
+          219,
+          0.7
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      rgba(
+          226,
+          230,
+          235,
+          0.72
+        )
+        1px,
+      transparent
+        1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(
+          226,
+          230,
+          235,
+          0.72
+        )
+        1px,
+      transparent
+        1px
     );
-  opacity: 0.95;
+  opacity: 0.72;
 }
 
 .light
   .blog-pattern::after {
-  background-image: radial-gradient(
-    900px
-      600px
-      at
-      85%
-      20%,
-    rgba(
-      139,
-      92,
-      246,
-      0.12
+  background-image:
+    linear-gradient(
+      to
+        right,
+      transparent
+        calc(
+          50% -
+            640px
+        ),
+      rgba(
+          203,
+          210,
+          219,
+          0.8
+        )
+        calc(
+          50% -
+            640px
+        ),
+      rgba(
+          203,
+          210,
+          219,
+          0.8
+        )
+        calc(
+          50% -
+            639px
+        ),
+      transparent
+        calc(
+          50% -
+            639px
+        ),
+      transparent
+        calc(
+          50% +
+            639px
+        ),
+      rgba(
+          203,
+          210,
+          219,
+          0.8
+        )
+        calc(
+          50% +
+            639px
+        ),
+      rgba(
+          203,
+          210,
+          219,
+          0.8
+        )
+        calc(
+          50% +
+            640px
+        ),
+      transparent
+        calc(
+          50% +
+            640px
+        )
     ),
-    transparent
-      75%
-  );
-  opacity: 0.35;
+    linear-gradient(
+      to
+        bottom,
+      rgba(
+          250,
+          250,
+          250,
+          0.72
+        ),
+      transparent
+        30%,
+      transparent
+        70%,
+      rgba(
+          250,
+          250,
+          250,
+          0.78
+        )
+    );
+  opacity: 1;
 }
 
 /* Background pattern for BlogDetail page - Even subtler for focused reading */

--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from "react";
-import { BookOpen } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { FileText } from "lucide-react";
 import { getBlogsByCategory, type BlogCategory } from "@/data/blogs";
 import BlogCard from "@/components/blogs/BlogCard";
 import { cn } from "@/lib";
@@ -20,18 +20,37 @@ const categories: (BlogCategory | "All")[] = [
   "Technical writer",
   "Opinions",
 ];
+
 const ITEMS_PER_PAGE = 10;
+
+const formatLatestDate = (dateString?: string) => {
+  if (!dateString) {
+    return "N/A";
+  }
+
+  return new Date(dateString)
+    .toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+    })
+    .toUpperCase();
+};
+
+const formatCategoryLabel = (category: BlogCategory | "All") =>
+  category === "All" ? "ALL_POSTS" : category.toUpperCase().replace(/\s+/g, "_");
 
 export default function Blogs() {
   const [selectedCategory, setSelectedCategory] = useState<
     BlogCategory | "All"
   >("All");
   const [currentPage, setCurrentPage] = useState(1);
+  const allBlogs = getBlogsByCategory("All");
   const filteredBlogs = getBlogsByCategory(selectedCategory);
   const totalPages = Math.ceil(filteredBlogs.length / ITEMS_PER_PAGE);
+  const latestBlog = allBlogs[0];
   const heroRef = useRef<HTMLDivElement>(null);
 
-  // Reset to page 1 when category changes
   useEffect(() => {
     setCurrentPage(1);
   }, [selectedCategory]);
@@ -58,69 +77,124 @@ export default function Blogs() {
   };
 
   return (
-    <div className="blog-pattern min-h-screen flex flex-col relative bg-slate-900 light:bg-slate-50">
+    <div className="blog-pattern min-h-screen flex flex-col relative bg-slate-950 light:bg-[#fafafa]">
       <div
         ref={heroRef}
-        className="mx-auto max-w-7xl px-6 w-full relative z-10 py-20 md:py-16"
+        className="mx-auto max-w-7xl px-4 sm:px-6 w-full relative z-10 py-10 md:py-14"
       >
-        <div
-          className="px-6 md:px-0 flex flex-col items-center gap-4 mb-12"
+        <header
+          className="border-y border-slate-800/70 light:border-[#e3e5e8]"
           style={{
-            animation: "fade-in 400ms ease-out both",
-            animationDelay: "60ms",
+            animation: "fade-in 420ms ease-out both",
+            animationDelay: "40ms",
           }}
         >
-          <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-300/60 bg-slate-900/60 light:bg-slate-100/60" aria-hidden="true">
-            <BookOpen className="h-6 w-6 text-slate-300 light:text-slate-700" />
-          </div>
-          <h1
-            className="text-4xl md:text-5xl text-center"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontWeight: 700,
-            }}
-          >
-            <span className="text-slate-100 light:text-slate-900">My </span>
-            <span className="text-slate-300 light:text-slate-700">Blog</span>
-          </h1>
-          <p
-            className="text-sm md:text-base text-center text-slate-500 light:text-slate-600"
-            style={{
-              fontFamily: "var(--font-body)",
-              fontWeight: 500,
-            }}
-          >
-            Thoughts, ideas, and experiences I want to share.
-          </p>
-        </div>
+          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <div className="relative px-0 py-10 md:py-14 lg:pr-14">
+              <div className="mb-8 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.28em] text-slate-500 light:text-[#8c929b]">
+                <span>01 // BLOG_INDEX</span>
+                <span className="hidden h-px w-16 bg-slate-700/70 light:bg-[#d7dbe0] sm:block" />
+              </div>
 
-        <div
-          className="flex flex-wrap items-center justify-center gap-2 mb-8"
-          role="tablist"
-          aria-label="Filter blog posts by category"
-        >
-          {categories.map((category) => (
-            <button
-              key={category}
-              role="tab"
-              aria-selected={selectedCategory === category}
-              aria-controls="blog-feed"
-              onClick={() => setSelectedCategory(category)}
-              className={cn(
-                "px-4 py-2 rounded-md border text-sm cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40",
-                selectedCategory === category
-                  ? "border-slate-700/70 light:border-slate-200/70 bg-slate-900/90 light:bg-white/90 text-slate-200 light:text-slate-800"
-                  : "border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 hover:border-slate-700/70 light:hover:border-slate-200/70 hover:bg-slate-900/80 light:hover:bg-slate-100/80 text-slate-400 light:text-slate-600"
-              )}
-              style={{
-                fontFamily: "var(--font-body)",
-                fontWeight: selectedCategory === category ? 600 : 500,
-              }}
+              <h1 className="max-w-4xl font-mono text-[48px] leading-[0.98] tracking-tight text-slate-100 light:text-[#111214] sm:text-[72px] md:text-[96px]">
+                Writing /
+                <br />
+                Notes
+              </h1>
+
+              <p className="mt-7 max-w-2xl font-body text-base font-medium leading-8 text-slate-400 light:text-[#5b5f66] md:text-lg">
+                Field notes, technical breakdowns, and personal essays from the
+                workbench. Built for scanning first, reading second.
+              </p>
+            </div>
+
+            <aside className="border-t border-slate-800/70 px-0 py-8 light:border-[#e3e5e8] lg:border-l lg:border-t-0 lg:px-8 lg:py-12">
+              <div className="mb-9 flex items-center justify-between gap-4 font-mono text-[11px] uppercase tracking-[0.24em] text-slate-500 light:text-[#8c929b]">
+                <span>02 // INDEX_META</span>
+                <span>BUILD:2026</span>
+              </div>
+
+              <dl className="grid grid-cols-2 gap-px overflow-hidden border border-slate-800/70 bg-slate-800/70 light:border-[#e3e5e8] light:bg-[#e3e5e8]">
+                <div className="bg-slate-950 px-4 py-5 light:bg-white">
+                  <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500 light:text-[#8c929b]">
+                    Posts
+                  </dt>
+                  <dd className="mt-2 font-mono text-3xl text-slate-100 light:text-[#111214]">
+                    {allBlogs.length}
+                  </dd>
+                </div>
+                <div className="bg-slate-950 px-4 py-5 light:bg-white">
+                  <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500 light:text-[#8c929b]">
+                    Routes
+                  </dt>
+                  <dd className="mt-2 font-mono text-3xl text-slate-100 light:text-[#111214]">
+                    {categories.length - 1}
+                  </dd>
+                </div>
+                <div className="col-span-2 bg-slate-950 px-4 py-5 light:bg-white">
+                  <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500 light:text-[#8c929b]">
+                    Latest dispatch
+                  </dt>
+                  <dd className="mt-2 font-mono text-sm uppercase tracking-[0.16em] text-slate-200 light:text-[#111214]">
+                    {formatLatestDate(latestBlog?.date)}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="mt-7 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.22em] text-[#22c55e]">
+                <span className="h-2 w-2 rounded-full bg-[#22c55e]" />
+                <span>ARCHIVE_LIVE</span>
+              </div>
+            </aside>
+          </div>
+        </header>
+
+        <section className="border-b border-slate-800/70 light:border-[#e3e5e8]">
+          <div className="grid grid-cols-1 gap-6 py-6 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
+            <div className="font-mono text-[11px] uppercase tracking-[0.24em] text-slate-500 light:text-[#8c929b]">
+              03 // ROUTES
+            </div>
+
+            <div
+              className="grid grid-cols-2 border border-slate-800/70 light:border-[#e3e5e8] sm:flex"
+              role="tablist"
+              aria-label="Filter blog posts by category"
             >
-              {category}
-            </button>
-          ))}
-        </div>
+              {categories.map((category) => {
+                const isActive = selectedCategory === category;
+
+                return (
+                  <button
+                    key={category}
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls="blog-feed"
+                    onClick={() => setSelectedCategory(category)}
+                    className={cn(
+                      "group relative min-h-12 border-b border-r border-slate-800/70 px-4 py-3 text-left font-mono text-[11px] uppercase tracking-[0.18em] transition-colors duration-200 last:border-r-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:border-[#e3e5e8] light:focus-visible:ring-slate-900/30 sm:border-b-0",
+                      isActive
+                        ? "bg-slate-100 text-slate-950 light:bg-[#111214] light:text-white"
+                        : "bg-slate-950/40 text-slate-400 hover:bg-slate-900/80 hover:text-slate-100 light:bg-white/70 light:text-[#5b5f66] light:hover:bg-[#f3f4f4] light:hover:text-[#111214]"
+                    )}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          "h-1.5 w-1.5 rounded-full transition-colors",
+                          isActive
+                            ? "bg-[#22c55e]"
+                            : "bg-slate-700 light:bg-[#d7dbe0]"
+                        )}
+                        aria-hidden="true"
+                      />
+                      {formatCategoryLabel(category)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </section>
 
         <div className="sr-only" aria-live="polite" role="status">
           {filteredBlogs.length === 0
@@ -128,42 +202,57 @@ export default function Blogs() {
             : `${filteredBlogs.length} blog post${filteredBlogs.length === 1 ? "" : "s"} found`}
         </div>
 
-        <div id="blog-feed" role="feed" aria-label="Blog posts" className="space-y-6">
+        <section
+          id="blog-feed"
+          role="feed"
+          aria-label="Blog posts"
+          className="border-b border-slate-800/70 light:border-[#e3e5e8]"
+        >
           {paginatedBlogs.length === 0 ? (
-            <div className="text-center py-12">
-              <p
-                className="text-slate-400 light:text-slate-600"
-                style={{
-                  fontFamily: "var(--font-body)",
-                  fontWeight: 400,
-                }}
-              >
-                No blogs found in this category.
-              </p>
+            <div className="grid grid-cols-1 gap-6 py-16 lg:grid-cols-[170px_minmax(0,1fr)]">
+              <div className="font-mono text-[11px] uppercase tracking-[0.24em] text-slate-500 light:text-[#8c929b]">
+                00 // EMPTY
+              </div>
+              <div className="border border-dashed border-slate-700 px-6 py-12 light:border-[#d7dbe0]">
+                <FileText
+                  className="mb-5 h-8 w-8 text-slate-500 light:text-[#8c929b]"
+                  aria-hidden="true"
+                />
+                <h2 className="font-mono text-2xl text-slate-100 light:text-[#111214]">
+                  No entries on this route
+                </h2>
+                <p className="mt-3 max-w-xl font-body text-sm font-medium leading-7 text-slate-400 light:text-[#5b5f66]">
+                  Try another category rail to inspect the rest of the writing
+                  archive.
+                </p>
+              </div>
             </div>
           ) : (
             paginatedBlogs.map((blog, index) => (
               <BlogCard key={blog.id} blog={blog} index={startIndex + index} />
             ))
           )}
-        </div>
+        </section>
 
         {totalPages > 1 && (
-          <div className="mt-14 flex flex-col items-center gap-4">
-            <div
-              className="inline-flex items-center gap-2 rounded-full border border-slate-800/60 light:border-slate-200/80 bg-slate-900/60 light:bg-white/70 px-4 py-1.5 text-xs uppercase tracking-[0.2em] text-slate-400 light:text-slate-600 shadow-[0_10px_30px_rgba(2,6,23,0.45)] light:shadow-[0_12px_25px_rgba(15,23,42,0.1)]"
-              aria-live="polite"
-            >
-              Page {currentPage} of {totalPages}
+          <section className="grid grid-cols-1 gap-6 py-7 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
+            <div className="font-mono text-[11px] uppercase tracking-[0.24em] text-slate-500 light:text-[#8c929b]">
+              04 // PAGE_CTRL
             </div>
-            <div className="w-full max-w-2xl rounded-2xl border border-slate-800/70 light:border-slate-200/80 bg-slate-950/65 light:bg-white/80 px-4 py-5 shadow-[0_35px_60px_rgba(2,6,23,0.65)] light:shadow-[0_25px_45px_rgba(15,23,42,0.15)] backdrop-blur-2xl">
-              <Pagination className="w-full">
-                <PaginationContent className="flex-wrap justify-center gap-2">
+
+            <div className="flex flex-col gap-4 border border-slate-800/70 bg-slate-950/50 p-3 light:border-[#e3e5e8] light:bg-white/70 md:flex-row md:items-center md:justify-between">
+              <div className="px-2 font-mono text-[11px] uppercase tracking-[0.22em] text-slate-400 light:text-[#5b5f66]">
+                Page {String(currentPage).padStart(2, "0")} /{" "}
+                {String(totalPages).padStart(2, "0")}
+              </div>
+
+              <Pagination className="mx-0 w-full justify-start md:w-auto md:justify-end">
+                <PaginationContent className="flex-wrap justify-start gap-1 md:justify-end">
                   <PaginationItem>
                     <PaginationPrevious
                       onClick={() => handlePageChange(currentPage - 1)}
                       disabled={currentPage === 1}
-                      className="px-5"
+                      className="h-10 rounded-none border-slate-800/70 bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none light:border-[#e3e5e8]"
                     />
                   </PaginationItem>
 
@@ -184,6 +273,7 @@ export default function Blogs() {
                             onClick={() => handlePageChange(page)}
                             isActive={page === currentPage}
                             aria-label={`Go to page ${page}`}
+                            className="h-10 w-10 rounded-none border-slate-800/70 bg-transparent font-mono text-[11px] shadow-none light:border-[#e3e5e8]"
                           >
                             {page}
                           </PaginationLink>
@@ -195,7 +285,7 @@ export default function Blogs() {
                     ) {
                       return (
                         <PaginationItem key={page}>
-                          <PaginationEllipsis />
+                          <PaginationEllipsis className="h-10 w-10 text-slate-500 light:text-[#8c929b]" />
                         </PaginationItem>
                       );
                     }
@@ -206,13 +296,13 @@ export default function Blogs() {
                     <PaginationNext
                       onClick={() => handlePageChange(currentPage + 1)}
                       disabled={currentPage === totalPages}
-                      className="px-5"
+                      className="h-10 rounded-none border-slate-800/70 bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none light:border-[#e3e5e8]"
                     />
                   </PaginationItem>
                 </PaginationContent>
               </Pagination>
             </div>
-          </div>
+          </section>
         )}
       </div>
     </div>


### PR DESCRIPTION
## What Change

- Redesigned the blog index page with a technical archive-style hero, route metadata, post count, category rail, empty state, and pagination controls in `src/pages/Blogs.tsx`.
- Reworked `BlogCard` into a feed-style article row with alternating image placement, author stats, category route labels, and improved image fallback behavior in `src/components/blogs/BlogCard.tsx`.
- Updated the Blogs page background treatment in `src/index.css` from a radial decorative pattern to a technical grid surface for dark and light themes.
- No dependency, lockfile, API, schema, or environment variable changes.

## Why Change

- The local `main` branch contained committed blog listing redesign work that was ahead of `origin/main`; this PR routes that work back into `main` through review instead of leaving origin stale.
- The previous blog listing presented a simpler card grid/list experience, while the new version emphasizes scannable archive navigation and richer metadata.

## Impact

- **Affected areas:** Blog index page, blog card component, blog page background styling.
- **Breaking changes:** No. Routes and data contracts remain unchanged.
- **Dependencies:** None.
- **Testing:** Ran `bun run build` successfully. Vite reported existing non-fatal warnings about large chunks and sourcemap reporting for `src/components/ui/separator.tsx`.