### PR TITLE
feat: redesign project list and detail pages

### DIFF
--- a/src/components/homepage/PortfolioCard.tsx
+++ b/src/components/homepage/PortfolioCard.tsx
@@ -12,125 +12,175 @@ interface PortfolioCardProps {
   index: number;
 }
 
-export default function PortfolioCard({ item }: PortfolioCardProps) {
+const getOutputState = (item: PortfolioItem) => {
+  if (item.liveUrl) {
+    return "LIVE_OUTPUT";
+  }
+
+  if (item.githubUrl) {
+    return "REPO_TRACE";
+  }
+
+  return "CASE_FILE";
+};
+
+export default function PortfolioCard({ item, index }: PortfolioCardProps) {
   const [imgError, setImgError] = useState(false);
   const [imgLoading, setImgLoading] = useState(true);
+  const outputState = getOutputState(item);
+  const primaryStack = item.techStack[0] ?? "Project";
+  const secondaryStack = item.techStack[1] ?? "Build";
+  const itemNumber = String(index + 1).padStart(2, "0");
 
   return (
-      <Card
-        role="article"
-        aria-label={item.title}
-        className={cn(
-          "group border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white motion-safe:transition-all motion-safe:duration-200 hover:border-slate-600/80 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:shadow-lg hover:shadow-slate-900/20 light:hover:shadow-slate-300/30 overflow-hidden flex flex-col h-full"
-        )}
-      >
-        <div className="flex flex-col sm:flex-row flex-1">
-          <div className="flex-1 p-3 sm:p-4 md:p-5 space-y-2 flex flex-col">
-            <CardHeader className="space-y-1.5 p-0 flex flex-col">
-              <h2
-                className="text-sm sm:text-base md:text-lg text-slate-100 light:text-slate-900 line-clamp-2 font-mono font-medium"
-              >
+    <Card
+      role="article"
+      aria-label={item.title}
+      className={cn(
+        "group flex h-full flex-col overflow-hidden rounded-none border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)] motion-safe:transition-colors motion-safe:duration-200 hover:border-[var(--border-strong)]"
+      )}
+    >
+      <div className="grid flex-1 grid-cols-1 sm:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="flex min-w-0 flex-col p-4 sm:p-5">
+          <div className="mb-5 flex items-center justify-between gap-4">
+            <span className="text-drawing-label">project_{itemNumber}</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--status-green)]">
+              {outputState}
+            </span>
+          </div>
+
+          <CardHeader className="space-y-3 p-0">
+            <h2 className="line-clamp-2 font-mono text-lg font-medium leading-snug text-[var(--graphite)]">
+              {item.title}
+            </h2>
+            <p className="line-clamp-4 font-body text-sm font-medium leading-7 text-[var(--graphite-muted)]">
+              {item.description}
+            </p>
+          </CardHeader>
+
+          <dl className="mt-5 grid grid-cols-2 gap-px border border-[var(--border-line)] bg-[var(--border-line)]">
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <dt className="text-drawing-label">Stack</dt>
+              <dd className="mt-1 truncate font-mono text-xs text-[var(--graphite)]">
+                {primaryStack}
+              </dd>
+            </div>
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <dt className="text-drawing-label">System</dt>
+              <dd className="mt-1 truncate font-mono text-xs text-[var(--graphite)]">
+                {secondaryStack}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="relative min-h-44 border-t border-[var(--border-line)] bg-[var(--surface-subtle)] sm:min-h-full sm:border-l sm:border-t-0">
+          <div
+            className="pointer-events-none absolute inset-0 z-10 border border-transparent"
+            aria-hidden="true"
+          >
+            <div className="absolute left-4 right-4 top-4 border-t border-dashed border-[var(--border-dashed)]" />
+            <div className="absolute bottom-4 left-4 right-4 border-t border-dashed border-[var(--border-dashed)]" />
+            <div className="absolute bottom-5 right-5 bg-[var(--paper)] px-2 py-1 font-mono text-[9px] uppercase tracking-[0.16em] text-[var(--graphite-muted)]">
+              output:{itemNumber}
+            </div>
+          </div>
+          {imgLoading && !imgError && (
+            <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-[var(--surface-subtle)]" />
+          )}
+          {imgError ? (
+            <div className="flex h-full min-h-44 w-full items-center justify-center bg-[var(--surface-subtle)] px-4">
+              <span className="line-clamp-3 text-center font-mono text-xs uppercase tracking-[0.14em] text-[var(--graphite-muted)]">
                 {item.title}
-              </h2>
-              <p
-                className="text-xs sm:text-sm text-slate-400 light:text-slate-600 line-clamp-4 font-body font-medium"
-              >
-                {item.description}
-              </p>
-            </CardHeader>
-          </div>
-          <div className="relative w-full sm:w-48 md:w-56 lg:w-64 flex-shrink-0 h-40 overflow-hidden bg-slate-800/40 light:bg-slate-100/60">
-            {imgLoading && !imgError && (
-              <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-slate-800/60" />
-            )}
-            {imgError ? (
-              <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
-                <span
-                  className="text-center text-xs text-slate-400 light:text-slate-500 line-clamp-3 font-body font-medium"
-                >
-                  {item.title}
-                </span>
-              </div>
-            ) : (
-              <img
-                src={item.image}
-                alt={item.title}
-                className="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-105"
-                loading="lazy"
-                decoding="async"
-                onLoad={() => setImgLoading(false)}
-                onError={() => setImgError(true)}
-              />
-            )}
-          </div>
+              </span>
+            </div>
+          ) : (
+            <img
+              src={item.image}
+              alt={item.title}
+              className="h-full min-h-44 w-full object-cover saturate-[0.9] motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]"
+              loading="lazy"
+              decoding="async"
+              onLoad={() => setImgLoading(false)}
+              onError={() => setImgError(true)}
+            />
+          )}
         </div>
-        <div className="border-t border-slate-800/70 light:border-slate-300 p-3 sm:p-4 md:p-4 space-y-2 sm:space-y-3 flex flex-col flex-1">
-          <div className="flex flex-wrap items-center gap-2" aria-label="Technologies used" role="list">
-            {item.techStack.slice(0, 5).map((tech) => {
-              const Icon = getTechIcon(tech);
-              if (!Icon) return null;
-              return (
-                <div
-                  key={tech}
-                  className="flex items-center gap-1 sm:gap-1.5 rounded border border-slate-800/70 light:border-slate-300 bg-slate-900/80 light:bg-slate-50 px-2 py-1 text-xs"
-                  title={tech}
-                  role="listitem"
-                >
-                  <Icon className="h-3 sm:h-3.5 w-3 sm:w-3.5 text-slate-400 light:text-slate-600" aria-hidden="true" />
-                  <span
-                    className="sr-only sm:not-sr-only sm:inline text-slate-400 light:text-slate-600 font-mono font-medium"
-                  >
-                    {tech}
-                  </span>
-                </div>
-              );
-            })}
-            {item.techStack.length > 5 && (
+      </div>
+
+      <div className="flex flex-col gap-4 border-t border-[var(--border-line)] p-4">
+        <div
+          className="flex flex-wrap items-center gap-2"
+          aria-label="Technologies used"
+          role="list"
+        >
+          {item.techStack.slice(0, 5).map((tech) => {
+            const Icon = getTechIcon(tech);
+            if (!Icon) return null;
+            return (
               <div
-                className="flex items-center gap-1 sm:gap-1.5 rounded border border-slate-800/70 light:border-slate-300 bg-slate-900/80 light:bg-slate-50 px-2 py-1 text-xs font-semibold"
-                title={item.techStack.slice(5).join(", ")}
+                key={tech}
+                className="flex items-center gap-1.5 rounded-none border border-[var(--border-line)] bg-[var(--paper)] px-2 py-1 text-xs"
+                title={tech}
+                role="listitem"
               >
-                <span className="text-slate-400 light:text-slate-600">
-                  +{item.techStack.length - 5}
+                <Icon
+                  className="h-3.5 w-3.5 text-[var(--graphite-muted)]"
+                  aria-hidden="true"
+                />
+                <span className="font-mono font-medium text-[var(--graphite-muted)]">
+                  {tech}
                 </span>
               </div>
-            )}
-          </div>
-          <div className="flex flex-wrap items-center gap-2 mt-auto">
-            <Link
-              to={`/projects/${item.slug}`}
-              className="inline-flex items-center gap-1 sm:gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-3 sm:px-4 py-2 text-xs sm:text-sm text-slate-300 light:text-slate-700 transition-all duration-200 hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 hover:shadow-md hover:shadow-slate-900/50 light:hover:shadow-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-semibold"
-              aria-label={`View ${item.title} project details`}
+            );
+          })}
+          {item.techStack.length > 5 && (
+            <div
+              className="flex items-center gap-1.5 rounded-none border border-[var(--border-line)] bg-[var(--paper)] px-2 py-1 text-xs font-semibold"
+              title={item.techStack.slice(5).join(", ")}
             >
-              Brief
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
-            {item.liveUrl && (
-              <a
-                href={item.liveUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-3 py-2 text-xs text-slate-300 light:text-slate-700 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                aria-label={`Visit ${item.title} live website`}
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Live Web
-              </a>
-            )}
-            {item.githubUrl && (
-              <a
-                href={item.githubUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300 bg-slate-900/60 light:bg-white px-3 py-2 text-xs text-slate-300 light:text-slate-700 transition-colors hover:border-slate-700/70 light:hover:border-slate-400 hover:bg-slate-900/90 light:hover:bg-slate-50 hover:text-slate-100 light:hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                aria-label={`View ${item.title} on GitHub`}
-              >
-                <Github className="h-3.5 w-3.5" />
-                Github
-              </a>
-            )}
-          </div>
+              <span className="font-mono text-[var(--graphite-muted)]">
+                +{item.techStack.length - 5}
+              </span>
+            </div>
+          )}
         </div>
-      </Card>
+
+        <div className="mt-auto flex flex-wrap items-center gap-2">
+          <Link
+            to={`/projects/${item.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-none border border-[var(--graphite)] bg-[var(--graphite)] px-3 py-2 font-body text-sm font-semibold text-[var(--paper)] transition-colors duration-200 hover:bg-[var(--graphite-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] active:translate-y-px"
+            aria-label={`View ${item.title} project details`}
+          >
+            Brief
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+          {item.liveUrl && (
+            <a
+              href={item.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-none border border-[var(--border-line)] bg-[var(--paper)] px-3 py-2 font-body text-xs font-medium text-[var(--graphite)] transition-colors duration-200 hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] active:translate-y-px"
+              aria-label={`Visit ${item.title} live website`}
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+              Live Web
+            </a>
+          )}
+          {item.githubUrl && (
+            <a
+              href={item.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-none border border-[var(--border-line)] bg-[var(--paper)] px-3 py-2 font-body text-xs font-medium text-[var(--graphite)] transition-colors duration-200 hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] active:translate-y-px"
+              aria-label={`View ${item.title} on GitHub`}
+            >
+              <Github className="h-3.5 w-3.5" aria-hidden="true" />
+              Github
+            </a>
+          )}
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/src/components/projects/TableOfContents.tsx
+++ b/src/components/projects/TableOfContents.tsx
@@ -101,22 +101,22 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
 
   return (
     <aside
-      className="hidden lg:block w-56 flex-shrink-0"
+      className="w-full"
       aria-label="Table of contents"
     >
       <div
-        className="sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto"
+        className="max-h-[calc(100vh-8rem)] overflow-y-auto border border-[var(--border-line)] bg-[var(--paper)] p-4 shadow-[var(--shadow-paper-xs)]"
         style={{
           scrollbarWidth: "thin",
-          scrollbarColor: "rgb(148 163 184 / 0.3) transparent",
+          scrollbarColor: "var(--border-strong) transparent",
         }}
       >
-        <p className="text-[11px] font-semibold uppercase tracking-widest text-slate-400 light:text-slate-500 mb-3 font-sans">
-          On this page
+        <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--graphite-muted)]">
+          03 // ON_THIS_PAGE
         </p>
 
         <nav aria-label="Table of contents">
-          <ul className="list-none m-0 p-0 border-l border-slate-800 light:border-slate-200">
+          <ul className="m-0 list-none border-l border-dashed border-[var(--border-dashed)] p-0">
             {groupedItems.map((group) => {
               const isExpanded = expandedSections.has(group.h2.id);
               const hasH3s = group.h3s.length > 0;
@@ -130,7 +130,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                     {/* Active indicator — overlays the border-l */}
                     {isSectionActive && (
                       <div
-                        className="absolute -left-px top-0 bottom-0 w-[2px] bg-blue-400 light:bg-blue-600"
+                        className="absolute -left-px top-0 bottom-0 w-[2px] bg-[var(--status-green)]"
                         aria-hidden="true"
                       />
                     )}
@@ -138,7 +138,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                     {hasH3s ? (
                       <button
                         onClick={() => toggleSection(group.h2.id)}
-                        className="flex-shrink-0 flex items-center justify-center w-6 h-6 mt-0.5 ml-2 text-slate-500 light:text-slate-400 hover:text-slate-300 light:hover:text-slate-700 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                        className="ml-2 mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center text-[var(--graphite-muted)] transition-colors hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]"
                         aria-label={
                           isExpanded
                             ? `Collapse ${group.h2.text}`
@@ -160,11 +160,11 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                       onClick={() => handleClick(group.h2.id)}
                       aria-current={isActive ? "true" : undefined}
                       className={cn(
-                        "flex-1 text-left py-1.5 pr-1 font-sans text-[13px] leading-[1.4] transition-colors duration-150 rounded-sm",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
+                        "flex-1 py-1.5 pr-1 text-left font-body text-[13px] font-medium leading-[1.45] transition-colors duration-150",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]",
                         isActive
-                          ? "text-blue-400 light:text-blue-600 font-medium"
-                          : "text-slate-400 light:text-slate-500 hover:text-slate-200 light:hover:text-slate-900"
+                          ? "text-[var(--status-green)]"
+                          : "text-[var(--graphite-muted)] hover:text-[var(--graphite)]"
                       )}
                     >
                       {group.h2.text}
@@ -188,11 +188,11 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                               onClick={() => handleClick(h3.id)}
                               aria-current={isH3Active ? "true" : undefined}
                               className={cn(
-                                "block w-full text-left py-1 pl-10 pr-1 font-sans text-[11px] leading-[1.4] transition-colors duration-150 rounded-sm",
-                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
+                                "block w-full py-1 pl-10 pr-1 text-left font-mono text-[10px] uppercase leading-[1.5] tracking-[0.12em] transition-colors duration-150",
+                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]",
                                 isH3Active
-                                  ? "text-blue-400 light:text-blue-600 font-medium"
-                                  : "text-slate-500 light:text-slate-400 hover:text-slate-300 light:hover:text-slate-800"
+                                  ? "text-[var(--status-green)]"
+                                  : "text-[var(--graphite-muted)] hover:text-[var(--graphite)]"
                               )}
                             >
                               {h3.text}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router";
-import { ArrowLeft, ExternalLink, Github } from "lucide-react";
+import { ArrowLeft, ExternalLink, FileCode2, Github } from "lucide-react";
 import { getProjectBySlug } from "@/data/portfolio";
 import { extractTOC } from "@/lib/toc";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
@@ -9,6 +9,22 @@ import { getTechIcon } from "@/lib/techIcons";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import FadeInUp from "@/components/common/FadeInUp";
+
+const formatDate = (dateString?: string) => {
+  if (!dateString) {
+    return "N/A";
+  }
+
+  return new Date(dateString)
+    .toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+    })
+    .toUpperCase();
+};
+
+const formatStackLabel = (tech: string) => tech.toUpperCase().replace(/\s+/g, "_");
 
 export default function ProjectDetail() {
   const { slug } = useParams<{
@@ -20,15 +36,19 @@ export default function ProjectDetail() {
 
   if (!project || !project.content) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-slate-950 light:bg-slate-50">
-        <div className="text-center">
-          <h1 className="text-2xl text-slate-100 light:text-slate-900 mb-4 font-mono font-bold">
+      <div className="drawing-sheet flex min-h-screen flex-col items-center justify-center bg-[var(--paper)] px-6">
+        <div className="border border-[var(--border-line)] bg-[var(--paper)] p-8 text-center shadow-[var(--shadow-paper-xs)]">
+          <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--graphite-muted)]">
+            00 // MISSING_ROUTE
+          </p>
+          <h1 className="mb-5 font-mono text-2xl text-[var(--graphite)]">
             Project not found
           </h1>
           <Link
             to="/projects"
-            className="text-slate-400 light:text-slate-600 hover:text-slate-200 light:hover:text-slate-800 motion-safe:transition-colors motion-safe:duration-200 font-body font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 rounded-md"
+            className="inline-flex items-center gap-2 border border-[var(--border-line)] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite)] transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]"
           >
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
             Back to Projects
           </Link>
         </div>
@@ -39,134 +59,245 @@ export default function ProjectDetail() {
   const toc = extractTOC(project.content);
 
   return (
-    <div className="project-detail-pattern min-h-screen flex flex-col relative bg-slate-950 light:bg-slate-50">
-      <div className="mx-auto max-w-6xl sm:px-6 w-full px-6 md:px-0 py-12 md:py-16 relative z-10">
-        <Link
-          to="/projects"
-          className="inline-flex items-center gap-2 mb-8 px-2 py-1 -ml-2 rounded-md text-slate-400 light:text-slate-600 hover:text-slate-200 light:hover:text-slate-800 hover:bg-slate-900/40 light:hover:bg-slate-100/60 motion-safe:transition-colors motion-safe:duration-200 font-body font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Projects
-        </Link>
+    <div className="project-detail-pattern relative flex min-h-screen flex-col bg-[var(--paper)]">
+      <div className="site-container relative z-10 w-full py-10 md:py-14">
+        <div className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+          <Link
+            to="/projects"
+            className="group flex items-center justify-between gap-4 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:px-5"
+          >
+            <span className="inline-flex items-center gap-2">
+              <ArrowLeft
+                className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+                aria-hidden="true"
+              />
+              route:/projects
+            </span>
+            <span className="hidden text-[var(--status-green)] sm:inline">
+              return_index
+            </span>
+          </Link>
+        </div>
 
-        <div className="flex flex-col lg:flex-row gap-8">
+        <section className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+          <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
+            <span>02 // PROJECT_META</span>
+            <span>BUILD:2026</span>
+          </div>
+
+          <div className="grid gap-px bg-[var(--border-line)] sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1.4fr_1.2fr]">
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                Type
+              </div>
+              <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
+                {project.type === "blog" ? "TECHNICAL_BLOG" : "PROJECT"}
+              </div>
+            </div>
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                Published
+              </div>
+              <div className="mt-1.5 font-mono text-[13px] uppercase tracking-[0.14em] text-[var(--graphite)]">
+                {formatDate(project.date)}
+              </div>
+            </div>
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                Stack
+              </div>
+              <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
+                {project.techStack.slice(0, 3).map(formatStackLabel).join(" / ")}
+              </div>
+            </div>
+            <div className="bg-[var(--paper)] px-3 py-3">
+              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                Pipeline
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em]">
+                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
+                  MD
+                </span>
+                <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
+                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
+                  ROUTE
+                </span>
+                <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
+                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--status-green)]">
+                  UI
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 border-t border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--status-green)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
+            PROJECT_READY
+          </div>
+        </section>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="flex-1 min-w-0">
             <FadeInUp delay={0.06}>
-            <article
-              className="space-y-6 bg-slate-900/30 light:bg-white/40 rounded-lg p-6 md:p-8 border border-slate-800/50 light:border-slate-200/50"
-              aria-labelledby="project-detail-heading"
-            >
-              <header className="space-y-4">
-                {/* Hero image with fallback */}
-                <div className="relative w-full h-64 md:h-80 lg:h-96 rounded-lg overflow-hidden border border-slate-800/70 light:border-slate-200/70 bg-slate-900/60 light:bg-white/60">
-                  {imgLoading && !imgError && project.image && (
-                    <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-slate-800/60" />
-                  )}
-                  {!project.image || imgError ? (
-                    <div className="flex h-full w-full items-center justify-center bg-slate-800/60 light:bg-slate-200/60 px-4">
-                      <span className="text-center text-sm text-slate-400 light:text-slate-500 font-body font-medium">
-                        {project.title}
+              <article
+                className="w-full max-w-full overflow-hidden border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]"
+                aria-labelledby="project-detail-heading"
+              >
+                <header className="relative overflow-hidden border-b border-[var(--border-line)]">
+                  <div
+                    className="pointer-events-none absolute inset-0 hidden md:block"
+                    aria-hidden="true"
+                  >
+                    <div className="absolute left-6 right-6 top-10 border-t border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute left-[58%] top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute left-6 top-10 h-px w-40 bg-[var(--status-green)]" />
+                  </div>
+
+                  <div className="relative z-10 px-4 py-8 sm:px-6 md:px-8 md:py-10">
+                    <div className="mb-7 flex flex-wrap items-center justify-between gap-4 font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--graphite-muted)]">
+                      <span>01 // PROJECT_MODULE</span>
+                      <span className="hidden text-[10px] tracking-[0.18em] md:inline">
+                        src/content/projects/{project.slug}.md
                       </span>
                     </div>
-                  ) : (
-                    <img
-                      src={project.image}
-                      alt={`Screenshot of ${project.title}`}
-                      className="w-full h-full object-cover motion-safe:transition-transform motion-safe:duration-300 group-hover:scale-[1.03]"
-                      loading="eager"
-                      decoding="async"
-                      onLoad={() => setImgLoading(false)}
-                      onError={() => setImgError(true)}
-                    />
-                  )}
-                </div>
 
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <h1 id="project-detail-heading" className="text-3xl md:text-4xl text-slate-100 light:text-slate-900 mb-2 font-mono font-bold">
-                      {project.title}
-                    </h1>
-                    <p className="text-base md:text-lg mb-4 font-blog font-normal leading-[1.75] text-slate-300 light:text-slate-700">
-                      {project.description}
-                    </p>
-                  </div>
-                  {project.type === "blog" && (
-                    <Badge
-                      variant="outline"
-                      className="border-slate-700/70 light:border-slate-300/70 text-slate-300 light:text-slate-600 bg-slate-900/40 light:bg-slate-100/40 font-body font-medium"
-                    >
-                      Technical Blog
-                    </Badge>
-                  )}
-                </div>
-
-                <div className="flex flex-wrap items-center gap-2">
-                  {project.techStack.slice(0, 5).map((tech) => {
-                    const Icon = getTechIcon(tech);
-                    return (
+                    <div className="relative isolate max-w-full overflow-hidden border border-[var(--border-line)] bg-[var(--paper)] px-4 py-5 sm:px-6 md:px-7">
                       <div
-                        key={tech}
-                        className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1 motion-safe:transition-colors motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-400"
-                        aria-label={tech}
+                        className="pointer-events-none absolute inset-0 z-0 hidden sm:block"
+                        aria-hidden="true"
                       >
-                        {Icon && (
-                          <Icon className="h-3.5 w-3.5 text-slate-400 light:text-slate-600" />
-                        )}
-                        <span className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium">
-                          {tech}
+                        <div className="absolute left-[7%] right-[7%] top-[52%] border-t border-dashed border-[var(--border-dashed)]" />
+                        <div className="absolute right-5 top-5 border border-[var(--border-line)] bg-[var(--paper)]/88 p-2 font-mono text-[9px] uppercase leading-5 tracking-[0.16em] text-[var(--graphite-muted)]">
+                          <div>GET /projects/{project.slug}</div>
+                          <div>MD - TSX</div>
+                          <div>VITE OK</div>
+                        </div>
+                      </div>
+                      <div className="relative z-10 max-w-4xl bg-[var(--paper)] pr-4">
+                        <Badge
+                          variant="outline"
+                          className="mb-4 rounded-none border-[var(--border-line)] bg-[var(--paper)] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--graphite-muted)]"
+                        >
+                          <span className="mr-2 h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
+                          {project.type === "blog" ? "Technical Blog" : "Project"}
+                        </Badge>
+                        <h1
+                          id="project-detail-heading"
+                          className="max-w-[290px] break-words pr-5 font-mono text-lg font-medium leading-[1.2] tracking-normal text-[var(--graphite)] sm:max-w-none sm:pr-0 sm:text-4xl md:text-5xl"
+                        >
+                          {project.title}
+                        </h1>
+                      </div>
+                    </div>
+
+                    <div className="mt-7 grid gap-5 md:grid-cols-[minmax(0,1fr)_220px] md:items-end">
+                      <p className="max-w-[290px] pr-5 font-body text-sm font-medium leading-7 text-[var(--graphite-muted)] sm:max-w-3xl sm:pr-0 md:text-lg md:leading-8">
+                        {project.description}
+                      </p>
+                      <div className="min-w-0 border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+                        <div className="break-all">ROUTE: /PROJECTS/{project.slug}</div>
+                        <div>SOURCE: MARKDOWN</div>
+                        <div>STATE: PUBLISHED</div>
+                      </div>
+                    </div>
+
+                    <div className="mt-7 flex flex-wrap items-center gap-2 border-t border-[var(--border-line)] pt-5">
+                      {project.techStack.map((tech) => {
+                        const Icon = getTechIcon(tech);
+                        return (
+                          <div
+                            key={tech}
+                            className="flex items-center gap-1.5 border border-[var(--border-line)] bg-[var(--paper)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--graphite-muted)] transition-colors hover:border-[var(--border-strong)]"
+                            aria-label={tech}
+                          >
+                            {Icon && (
+                              <Icon
+                                className="h-3.5 w-3.5 text-[var(--graphite-muted)]"
+                                aria-hidden="true"
+                              />
+                            )}
+                            <span>{tech}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    <div className="mt-5 flex flex-wrap items-center gap-3">
+                      {project.liveUrl && (
+                        <a
+                          href={project.liveUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 border border-[var(--border-line)] bg-[var(--graphite)] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--paper)] transition-colors hover:bg-[var(--graphite-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)]"
+                          aria-label={`Visit ${project.title} live website`}
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                          Live Demo
+                        </a>
+                      )}
+                      {project.githubUrl && (
+                        <a
+                          href={project.githubUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 border border-[var(--border-line)] bg-[var(--paper)] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--graphite)] transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]"
+                          aria-label={`View ${project.title} on GitHub`}
+                        >
+                          <Github className="h-3.5 w-3.5" aria-hidden="true" />
+                          View Code
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </header>
+
+                <div className="border-b border-[var(--border-line)]">
+                  <div className="flex items-center justify-between border-b border-[var(--border-line)] bg-[var(--surface-subtle)] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] sm:px-6 md:px-8">
+                    <span className="inline-flex items-center gap-2">
+                      <FileCode2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      asset.project
+                    </span>
+                    <span className="hidden sm:inline">render:image</span>
+                  </div>
+
+                  <div className="relative h-64 w-full bg-[var(--surface-subtle)] md:h-80 lg:h-96">
+                    {imgLoading && !imgError && project.image && (
+                      <Skeleton className="absolute inset-0 h-full w-full rounded-none bg-[var(--surface-subtle)]" />
+                    )}
+                    {!project.image || imgError ? (
+                      <div className="flex h-full w-full items-center justify-center px-4">
+                        <span className="text-center font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)]">
+                          {project.title}
                         </span>
                       </div>
-                    );
-                  })}
-                  {project.techStack.length > 5 && (
-                    <div
-                      className="flex items-center gap-1.5 rounded border border-slate-800/70 light:border-slate-300/70 bg-slate-900/80 light:bg-white/60 px-2 py-1 font-semibold motion-safe:transition-colors motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-400"
-                      aria-label={`${project.techStack.length - 5} more technologies: ${project.techStack.slice(5).join(", ")}`}
-                    >
-                      <span className="text-xs text-slate-400 light:text-slate-600 font-mono font-medium">
-                        +{project.techStack.length - 5}
-                      </span>
-                    </div>
-                  )}
+                    ) : (
+                      <img
+                        src={project.image}
+                        alt={`Screenshot of ${project.title}`}
+                        className="h-full w-full object-cover grayscale"
+                        loading="eager"
+                        decoding="async"
+                        onLoad={() => setImgLoading(false)}
+                        onError={() => setImgError(true)}
+                      />
+                    )}
+                  </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-3 pt-2">
-                  {project.liveUrl && (
-                    <a
-                      href={project.liveUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 motion-safe:transition-colors motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                      aria-label={`Visit ${project.title} live website`}
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                      Live Demo
-                    </a>
-                  )}
-                  {project.githubUrl && (
-                    <a
-                      href={project.githubUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-slate-800/70 light:border-slate-300/70 bg-slate-900/60 light:bg-slate-100/60 px-4 py-2 text-sm text-slate-300 light:text-slate-600 motion-safe:transition-colors motion-safe:duration-200 hover:border-slate-700/70 light:hover:border-slate-300 hover:bg-slate-900/90 light:hover:bg-slate-100/80 hover:text-slate-100 light:hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/40 light:focus-visible:ring-slate-900/40 font-body font-medium"
-                      aria-label={`View ${project.title} on GitHub`}
-                    >
-                      <Github className="h-4 w-4" />
-                      View Code
-                    </a>
-                  )}
+                <div className="mx-auto max-w-3xl px-4 py-8 pr-8 sm:px-6 md:px-8 md:py-10">
+                  <MarkdownRenderer content={project.content} />
                 </div>
-              </header>
-
-              {/* Content */}
-              <div className="max-w-prose mx-auto">
-                <MarkdownRenderer content={project.content} />
-              </div>
-            </article>
+              </article>
             </FadeInUp>
           </div>
 
-          {toc.length > 0 && <TableOfContents items={toc} />}
+          {toc.length > 0 && (
+            <aside className="hidden lg:block">
+              <div className="sticky top-24">
+                <TableOfContents items={toc} />
+              </div>
+            </aside>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,492 +1,286 @@
-import { Folder } from "lucide-react";
-import { portfolioItems } from "@/data/portfolio";
-import PortfolioCard from "@/components/homepage/PortfolioCard";
 import FadeInUp from "@/components/common/FadeInUp";
+import PortfolioCard from "@/components/homepage/PortfolioCard";
+import { portfolioItems } from "@/data/portfolio";
 
-const ProjectBackground = () => (
+const formatLatestDate = (dateString?: string) => {
+  if (!dateString) {
+    return "N/A";
+  }
+
+  return new Date(dateString)
+    .toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+    })
+    .toUpperCase();
+};
+
+const uniqueStacks = Array.from(
+  new Set(portfolioItems.flatMap((item) => item.techStack))
+);
+
+const latestProject = portfolioItems.find((item) => item.date);
+
+const RouteChipGraph = () => (
   <svg
-    viewBox="0 0 1153 800"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    className="absolute overflow-hidden top-6 inset-x-0 md:top-10 lg:w-full z-[-1] md:max-w-[68rem] lg:max-w-7xl mx-auto opacity-15 md:opacity-30 lg:opacity-40 text-slate-100/20 light:text-slate-500/40"
-    aria-hidden="true"
+    viewBox="0 0 320 320"
+    role="img"
+    aria-labelledby="route-chip-title route-chip-desc"
+    className="h-full w-full text-[var(--graphite-muted)]"
   >
-    <path
-      d="M59.311 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M86.6379 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M113.948 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M141.275 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M168.586 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M195.897 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M223.224 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M250.535 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M277.845 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M305.172 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M332.483 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M359.81 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M387.121 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M414.432 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M441.758 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M469.069 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M496.396 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M523.707 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M551.018 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M578.344 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M605.656 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M632.982 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M660.293 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M687.604 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M714.931 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M742.242 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M769.568 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M796.879 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M824.19 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M851.517 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M878.828 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M906.139 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M933.465 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M960.776 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M988.103 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1015.41 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1042.72 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1070.05 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1097.36 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.09307"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1124.69 74.5547V798.515"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 771.695H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 744.891H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 718.071H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 691.268H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 664.448H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 637.628H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 610.824H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 584.004H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 557.2H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 530.38H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 503.561H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 476.756H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 449.937H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 423.133H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 396.313H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 369.493H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 342.689H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 315.87H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 289.065H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 262.246H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 235.442H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 208.622H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 181.802H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 154.998H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 128.179H32"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
-    <path
-      d="M1152 101.374H32"
-      stroke="currentColor"
-      strokeWidth="1.58416"
-      strokeMiterlimit="10"
-      strokeDasharray="3.17 3.17"
-    />
-    <path
-      d="M1152 74.5547H32V798.515H1152V74.5547Z"
-      stroke="currentColor"
-      strokeWidth="1.10891"
-      strokeMiterlimit="10"
-    />
+    <title id="route-chip-title">Route chip graph</title>
+    <desc id="route-chip-desc">
+      Project markdown files move through data, card, link, and UI nodes.
+    </desc>
+    <rect
+      x="28"
+      y="28"
+      width="264"
+      height="264"
+      fill="var(--paper)"
+      stroke="var(--border-line)"
+    />
+    <rect
+      x="72"
+      y="72"
+      width="176"
+      height="176"
+      fill="none"
+      stroke="var(--border-dashed)"
+      strokeDasharray="4 5"
+    />
+    <path
+      d="M88 112H42M88 152H42M88 192H42M278 112H232M278 152H232M278 192H232"
+      stroke="var(--border-line)"
+    />
+    <path
+      d="M128 48V88M160 48V88M192 48V88M128 232V272M160 232V272M192 232V272"
+      stroke="var(--border-line)"
+    />
+    <path
+      d="M106 106H214V214H106V106Z"
+      fill="var(--paper)"
+      stroke="var(--border-line)"
+    />
+    <path
+      d="M126 126H178V178H140V154H160V144H126V126Z"
+      fill="none"
+      stroke="var(--status-green)"
+      strokeWidth="2"
+    />
+    <path
+      d="M178 126C210 126 226 142 226 166C226 198 202 214 170 214H126"
+      fill="none"
+      stroke="var(--border-dashed)"
+      strokeDasharray="4 5"
+    />
+    <path
+      d="M82 88H128M192 88H238M82 232H128M192 232H238M82 88V232M238 88V232"
+      stroke="var(--border-dashed)"
+      strokeDasharray="4 5"
+    />
+    <g className="font-mono text-[11px] uppercase tracking-[0.18em]">
+      <rect
+        x="60"
+        y="72"
+        width="44"
+        height="32"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <text x="82" y="92" textAnchor="middle" fill="currentColor">
+        MD
+      </text>
+      <rect
+        x="216"
+        y="72"
+        width="44"
+        height="32"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <text x="238" y="92" textAnchor="middle" fill="currentColor">
+        DATA
+      </text>
+      <rect
+        x="54"
+        y="216"
+        width="56"
+        height="32"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <text x="82" y="236" textAnchor="middle" fill="currentColor">
+        CARD
+      </text>
+      <rect
+        x="210"
+        y="216"
+        width="56"
+        height="32"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <text x="238" y="236" textAnchor="middle" fill="currentColor">
+        LINK
+      </text>
+      <rect
+        x="136"
+        y="266"
+        width="48"
+        height="28"
+        fill="var(--paper)"
+        stroke="var(--border-line)"
+      />
+      <text x="160" y="284" textAnchor="middle" fill="var(--status-green)">
+        UI
+      </text>
+    </g>
   </svg>
 );
 
 export default function Projects() {
   return (
-    <div className="min-h-screen flex flex-col relative bg-slate-950 light:bg-slate-50">
-      <div className="bg-pattern-projects" aria-hidden="true" />
-      <ProjectBackground />
-      <div className="mx-auto max-w-7xl px-6 w-full relative z-10 py-20 md:py-16">
+    <div className="drawing-sheet min-h-screen">
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 md:py-14">
         <FadeInUp delay={0.06}>
-          <div className="px-6 md:px-0 flex flex-col items-center gap-4 mb-12">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700/60 light:border-slate-200/70 bg-slate-900/60 light:bg-white/80">
-              <Folder className="h-6 w-6 text-slate-300 light:text-slate-700" />
+          <header className="relative overflow-hidden border border-[var(--border-line)] bg-[var(--paper)]/82 shadow-[var(--shadow-paper-xs)]">
+            <div
+              className="pointer-events-none absolute inset-0 hidden lg:block"
+              aria-hidden="true"
+            >
+              <div className="absolute left-8 right-8 top-10 border-t border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-8 right-8 bottom-10 border-t border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-[35%] top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-[68%] top-0 bottom-0 border-l border-dashed border-[var(--border-dashed)]" />
+              <div className="absolute left-8 top-10 h-px w-40 bg-[var(--status-green)]" />
+              <span className="coordinate-label absolute left-[35%] top-6 -translate-x-1/2">
+                SYSTEM_SCOPE
+              </span>
+              <span className="coordinate-label absolute left-[68%] top-6 -translate-x-1/2">
+                PRIMARY_OUTPUT
+              </span>
             </div>
-            <h1
-              className="text-4xl md:text-5xl text-center font-mono font-bold"
-            >
-              <span className="text-slate-100 light:text-slate-900">
-                Curated{" "}
-              </span>
-              <span className="text-slate-300 light:text-slate-600">
-                Projects
-              </span>
-            </h1>
-            <p
-              className="text-sm md:text-base text-slate-400 light:text-slate-600 text-center font-body font-medium"
-            >
-              Showcase of my projects that I'm proud of.
-            </p>
-          </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]">
+              <div className="relative px-5 py-10 sm:px-6 md:px-8 md:py-14 lg:pr-14">
+                <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+                  <div className="flex items-center gap-3 text-drawing-label">
+                    <span>01 // WORK_INDEX</span>
+                    <span className="hidden h-px w-16 bg-[var(--border-line)] sm:block" />
+                  </div>
+                  <div className="hidden gap-6 text-drawing-label sm:flex">
+                    <span>src/pages/Projects.tsx</span>
+                    <span>route:/projects</span>
+                  </div>
+                </div>
+
+                <div className="relative isolate max-w-4xl overflow-hidden border border-[var(--border-line)] bg-[var(--paper)] px-4 py-5 sm:px-6 md:px-7">
+                  <div
+                    className="pointer-events-none absolute inset-0 z-0 hidden sm:block"
+                    aria-hidden="true"
+                  >
+                    <div className="absolute left-[8%] right-[8%] top-[50%] border-t border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute left-[48%] top-[12%] bottom-[12%] border-l border-dashed border-[var(--border-dashed)]" />
+                    <div className="absolute right-5 top-5 border border-[var(--border-line)] bg-[var(--paper)]/76 p-2 font-mono text-[9px] uppercase leading-5 tracking-[0.16em] text-[var(--graphite-muted)]">
+                      <div>GET /projects</div>
+                      <div>MD - TSX</div>
+                      <div>VITE OK</div>
+                    </div>
+                    <div className="absolute right-12 bottom-5 grid grid-cols-3 gap-1">
+                      <span className="h-2 w-2 bg-[var(--status-green)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                      <span className="h-2 w-2 bg-[var(--status-green)]" />
+                      <span className="h-2 w-2 bg-[var(--border-line)]" />
+                    </div>
+                  </div>
+                  <h1 className="relative z-10 inline-block bg-[var(--paper)] pr-5 font-mono text-[44px] font-medium leading-[0.98] tracking-normal text-[var(--graphite)] sm:text-[72px] md:text-[96px]">
+                    Curated
+                    <br />
+                    Projects
+                  </h1>
+                </div>
+
+                <div className="mt-7 grid gap-5 md:grid-cols-[minmax(0,1fr)_220px] md:items-end">
+                  <p className="text-body-readable text-base font-medium md:text-lg">
+                    Software work catalog: shipped products, backend systems,
+                    content sites, and experiments mapped from source files to
+                    public outputs.
+                  </p>
+                  <div className="border-l border-[var(--border-line)] pl-4 font-mono text-[10px] uppercase leading-6 tracking-[0.2em] text-[var(--graphite-muted)]">
+                    <div>ROUTE: /PROJECTS</div>
+                    <div>SOURCE: MD_FILES</div>
+                    <div>RENDER: WORK_CARD</div>
+                  </div>
+                </div>
+              </div>
+
+              <aside className="border-t border-[var(--border-line)] px-5 py-8 sm:px-6 lg:border-l lg:border-t-0 lg:px-8 lg:py-12">
+                <div className="mb-9 flex items-center justify-between gap-4 text-drawing-label">
+                  <span>02 // BUILD_META</span>
+                  <span>BUILD:2026</span>
+                </div>
+
+                <dl className="grid grid-cols-2 gap-px border border-[var(--border-line)] bg-[var(--border-line)]">
+                  <div className="bg-[var(--paper)] px-4 py-5">
+                    <dt className="text-drawing-label">Projects</dt>
+                    <dd className="mt-2 font-mono text-3xl text-[var(--graphite)]">
+                      {portfolioItems.length}
+                    </dd>
+                  </div>
+                  <div className="bg-[var(--paper)] px-4 py-5">
+                    <dt className="text-drawing-label">Stacks</dt>
+                    <dd className="mt-2 font-mono text-3xl text-[var(--graphite)]">
+                      {uniqueStacks.length}
+                    </dd>
+                  </div>
+                  <div className="col-span-2 bg-[var(--paper)] px-4 py-5">
+                    <dt className="text-drawing-label">Latest output</dt>
+                    <dd className="mt-2 font-mono text-sm uppercase tracking-[0.16em] text-[var(--graphite)]">
+                      {formatLatestDate(latestProject?.date)}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="mt-7 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--status-green)]">
+                  <span className="h-2 w-2 rounded-full bg-[var(--status-green)]" />
+                  <span>PRIMARY_OUTPUT_READY</span>
+                </div>
+
+                <div className="mt-10 hidden border border-dashed border-[var(--border-dashed)] p-4 lg:block">
+                  <div className="mb-4 text-drawing-label">Route graph</div>
+                  <div className="aspect-square overflow-hidden">
+                    <RouteChipGraph />
+                  </div>
+                </div>
+              </aside>
+            </div>
+          </header>
         </FadeInUp>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 auto-rows-fr" role="list" aria-label="Project list">
-          {portfolioItems.map((item, index) => (
-            <FadeInUp key={item.id} delay={0.1 + index * 0.08}>
-              <div role="listitem" className="h-full">
-                <PortfolioCard item={item} index={index} />
-              </div>
-            </FadeInUp>
-          ))}
-        </div>
+        <section className="border-b border-[var(--border-line)] py-8">
+          <div className="mb-5 flex items-center gap-3 text-drawing-label">
+            <span>03 // WORK_RECORDS</span>
+            <span className="hidden h-px flex-1 bg-[var(--border-line)] sm:block" />
+            <span className="hidden sm:inline">source:content/projects</span>
+          </div>
+          <div
+            className="grid grid-cols-1 gap-4 md:grid-cols-2"
+            role="list"
+            aria-label="Project list"
+          >
+            {portfolioItems.map((item, index) => (
+              <FadeInUp key={item.id} delay={0.1 + index * 0.08}>
+                <div role="listitem" className="h-full">
+                  <PortfolioCard item={item} index={index} />
+                </div>
+              </FadeInUp>
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## What Change

- Reworked `src/pages/Projects.tsx` into a drawing-sheet style project index with route metadata, stack summaries, project counts, and a denser project list layout.
- Updated `src/pages/ProjectDetail.tsx` with the same editorial/drawing-sheet treatment, including structured project metadata, route breadcrumbs, image fallback handling, and article/content framing.
- Refreshed `src/components/homepage/PortfolioCard.tsx` so project cards match the redesigned project surface and preserve accessible project links/images.
- Adjusted `src/components/projects/TableOfContents.tsx` styling to align the detail page sidebar with the new visual system.

## Why Change

- Restores the project list and project detail redesign that was previously sitting only on the local `codex/about-drawing-sheet-redesign` checkpoint branch.
- Keeps the MR scoped to the project-related redesign files instead of bringing unrelated About, Blog, docs, or Playwright artifact changes from that checkpoint branch.
- Brings the project pages back in line with the newer drawing-sheet/editorial design direction already present elsewhere in the site.

## Impact

- **Affected areas:** `/projects`, `/projects/:slug`, homepage portfolio cards, project detail table of contents.
- **Breaking changes:** No. This is a UI/component redesign with no route, content schema, or API contract changes.
- **Dependencies:** No new package or lockfile changes.
- **Testing:** `bun run build` passes in the clean worktree. Vite reports the existing large chunk warning after successful build.