### PR TITLE
feat: add subtle site-wide animation pass

### DIFF
--- a/src/components/blogs/BlogCard.tsx
+++ b/src/components/blogs/BlogCard.tsx
@@ -25,7 +25,6 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
   const [views, setViews] = useState(0);
   const [likes, setLikes] = useState(0);
   const [imgError, setImgError] = useState(false);
-  const animationDelay = `${80 + (index % 10) * 40}ms`;
   const hasImage = Boolean(blog.image);
   const imageOnRight = index % 2 === 0;
 
@@ -77,10 +76,6 @@ export default function BlogCard({ blog, index }: BlogCardProps) {
       aria-label={blog.title}
       onClick={handleCardClick}
       className="motion-card group grid cursor-pointer grid-cols-1 border-t border-[var(--border-line)] lg:grid-cols-[170px_minmax(0,1fr)]"
-      style={{
-        animation: "fade-in 420ms ease-out both",
-        animationDelay,
-      }}
     >
       <div className="border-b border-[var(--border-line)] py-5 font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--graphite-muted)] lg:border-b-0 lg:py-8 lg:pr-8">
         {String(index + 1).padStart(2, "0")} // ENTRY

--- a/src/components/common/FadeInUp.tsx
+++ b/src/components/common/FadeInUp.tsx
@@ -1,5 +1,5 @@
-import { motion, useReducedMotion } from 'framer-motion'
-import { ReactNode } from 'react'
+import { motion, useReducedMotion, type ViewportOptions } from 'framer-motion'
+import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 interface FadeInUpProps {
@@ -7,21 +7,23 @@ interface FadeInUpProps {
   className?: string
   delay?: number
   duration?: number
-  animateOpacity?: boolean
+  distance?: number
+  viewport?: ViewportOptions
 }
 
 const FadeInUp = ({
   children,
   className,
-  delay = 0.12,
-  duration = 0.8,
-  animateOpacity = false,
+  delay = 0.08,
+  duration = 0.45,
+  distance = 16,
+  viewport = { once: true, margin: '-48px 0px -80px' },
 }: FadeInUpProps) => {
   const prefersReducedMotion = useReducedMotion()
 
   const initialState = prefersReducedMotion
     ? { y: 0, opacity: 1 }
-    : { y: 20, opacity: animateOpacity ? 0 : 1 }
+    : { y: distance, opacity: 0 }
 
   const animateState = {
     y: 0,
@@ -32,7 +34,7 @@ const FadeInUp = ({
     <motion.div
       initial={initialState}
       whileInView={animateState}
-      viewport={{ once: true, margin: '-50px' }}
+      viewport={viewport}
       transition={{
         duration: prefersReducedMotion ? 0 : duration,
         delay: prefersReducedMotion ? 0 : delay,

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,10 +1,15 @@
-import { Outlet } from 'react-router'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { useLocation, useOutlet } from 'react-router'
 import Header from './Header'
 import Footer from './Footer'
 import ScrollToTop from './ScrollToTop'
 import ConnectCTA from '@/components/sections/ConnectCTA'
 
 export default function Layout() {
+  const location = useLocation()
+  const outlet = useOutlet()
+  const prefersReducedMotion = useReducedMotion()
+
   return (
     <div className="min-h-screen flex flex-col">
       <a
@@ -16,7 +21,20 @@ export default function Layout() {
       <ScrollToTop />
       <Header />
       <main id="main-content" className="flex-1 pt-16">
-        <Outlet />
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={location.pathname}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={prefersReducedMotion ? undefined : { opacity: 0, y: -6 }}
+            transition={{
+              duration: prefersReducedMotion ? 0 : 0.22,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+          >
+            {outlet}
+          </motion.div>
+        </AnimatePresence>
       </main>
       <ConnectCTA />
       <Footer />

--- a/src/components/common/StaggerGroup.tsx
+++ b/src/components/common/StaggerGroup.tsx
@@ -1,0 +1,72 @@
+import { motion, useReducedMotion, type Variants } from 'framer-motion'
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface StaggerGroupProps {
+  children: ReactNode
+  className?: string
+  staggerDelay?: number
+  initialDelay?: number
+  viewportMargin?: string
+}
+
+interface StaggerItemProps {
+  children: ReactNode
+  className?: string
+}
+
+const itemVariants: Variants = {
+  hidden: { y: 14, opacity: 0 },
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: { duration: 0.36, ease: [0.22, 1, 0.36, 1] },
+  },
+}
+
+export function StaggerGroup({
+  children,
+  className,
+  staggerDelay = 0.06,
+  initialDelay = 0,
+  viewportMargin = '-48px 0px -80px',
+}: StaggerGroupProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  const containerVariants: Variants = {
+    hidden: {},
+    visible: {
+      transition: prefersReducedMotion
+        ? { staggerChildren: 0, delayChildren: 0 }
+        : { staggerChildren: staggerDelay, delayChildren: initialDelay },
+    },
+  }
+
+  return (
+    <motion.div
+      initial={prefersReducedMotion ? 'visible' : 'hidden'}
+      whileInView="visible"
+      viewport={{ once: true, margin: viewportMargin, amount: 0.12 }}
+      variants={containerVariants}
+      className={cn(className)}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export function StaggerItem({ children, className }: StaggerItemProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={cn(className)}>{children}</div>
+  }
+
+  return (
+    <motion.div variants={itemVariants} className={cn(className)}>
+      {children}
+    </motion.div>
+  )
+}
+
+export default StaggerGroup

--- a/src/components/design-system/BlueprintCommandHero.tsx
+++ b/src/components/design-system/BlueprintCommandHero.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import FadeInUp from '@/components/common/FadeInUp'
+import { StaggerGroup, StaggerItem } from '@/components/common/StaggerGroup'
 import DrawingFrame from '@/components/design-system/DrawingFrame'
 import MetadataRow from '@/components/design-system/MetadataRow'
 import RouteRail from '@/components/design-system/RouteRail'
@@ -61,8 +62,12 @@ export default function BlueprintCommandHero({
               className="absolute left-0 top-0 h-px w-32 bg-[var(--status-green)]"
               aria-hidden="true"
             />
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
-              <div className="space-y-7">
+            <StaggerGroup
+              className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]"
+              staggerDelay={0.055}
+              initialDelay={0.08}
+            >
+              <StaggerItem className="space-y-7">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <TechnicalLabel variant="mono">01 // {eyebrow}</TechnicalLabel>
                   <TechnicalLabel variant="status">{statusLabel}</TechnicalLabel>
@@ -84,23 +89,27 @@ export default function BlueprintCommandHero({
                   <MetadataRow items={metadata} />
                   <p className="text-body-readable">{description}</p>
                 </div>
-              </div>
+              </StaggerItem>
 
-              <aside
-                className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
-                aria-label={`${eyebrow} routes`}
-              >
-                <TechnicalLabel variant="mono">02 // ROUTES</TechnicalLabel>
-                <RouteRail items={routes} ariaLabel={`${eyebrow} route links`} />
-              </aside>
-            </div>
+              <StaggerItem>
+                <aside
+                  className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
+                  aria-label={`${eyebrow} routes`}
+                >
+                  <TechnicalLabel variant="mono">02 // ROUTES</TechnicalLabel>
+                  <RouteRail items={routes} ariaLabel={`${eyebrow} route links`} />
+                </aside>
+              </StaggerItem>
+            </StaggerGroup>
 
-            <div className="mt-9 border-t border-[var(--border-line)] pt-5">
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                <MetadataRow items={footerMetadata} />
-                <TechnicalLabel variant="mono">BUILD:2026</TechnicalLabel>
+            <FadeInUp delay={0.18} duration={0.36}>
+              <div className="mt-9 border-t border-[var(--border-line)] pt-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <MetadataRow items={footerMetadata} />
+                  <TechnicalLabel variant="mono">BUILD:2026</TechnicalLabel>
+                </div>
               </div>
-            </div>
+            </FadeInUp>
           </div>
         </FadeInUp>
       </section>

--- a/src/components/design-system/BlueprintIndexHero.tsx
+++ b/src/components/design-system/BlueprintIndexHero.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { ArrowRight } from 'lucide-react'
 import FadeInUp from '@/components/common/FadeInUp'
+import { StaggerGroup, StaggerItem } from '@/components/common/StaggerGroup'
 import DrawingFrame from '@/components/design-system/DrawingFrame'
 import MetadataRow from '@/components/design-system/MetadataRow'
 import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
@@ -71,8 +72,12 @@ export default function BlueprintIndexHero({
               aria-hidden="true"
             />
 
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
-              <div className="min-w-0 space-y-7">
+            <StaggerGroup
+              className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]"
+              staggerDelay={0.055}
+              initialDelay={0.08}
+            >
+              <StaggerItem className="min-w-0 space-y-7">
                 <div className="flex flex-wrap items-center justify-between gap-4 border-b border-dashed border-[var(--border-dashed)] pb-5">
                   <TechnicalLabel variant="mono">01 // {eyebrow}</TechnicalLabel>
                   <TechnicalLabel variant="status">{statusLabel}</TechnicalLabel>
@@ -90,55 +95,57 @@ export default function BlueprintIndexHero({
                 <div className="max-w-2xl md:pl-6">
                   <p className="text-body-readable max-w-2xl">{description}</p>
                 </div>
-              </div>
+              </StaggerItem>
 
-              <aside
-                className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
-                aria-label={`${eyebrow} metadata`}
-              >
-                <div className="grid grid-cols-2 border border-[var(--border-line)]">
-                  {stats.slice(0, 2).map((stat, index) => (
-                    <div
-                      key={stat.label}
-                      className={cn('p-4', index === 0 && 'border-r border-[var(--border-line)]')}
-                    >
-                      <TechnicalLabel>{stat.label}</TechnicalLabel>
-                      <p className="mt-4 font-mono text-3xl text-[var(--graphite)]">
-                        {stat.value}
-                      </p>
-                    </div>
-                  ))}
-                  {latestLabel && latestValue && (
-                    <div className="col-span-2 border-t border-[var(--border-line)] p-4">
-                      <TechnicalLabel>{latestLabel}</TechnicalLabel>
-                      <p className="mt-4 font-mono text-sm uppercase tracking-[0.16em] text-[var(--graphite)]">
-                        {latestValue}
-                      </p>
-                    </div>
-                  )}
-                </div>
-
-                <div className="mt-8 space-y-4">
-                  <MetadataRow items={metadata} />
-                  {actionHref && (
-                    <a
-                      href={actionHref}
-                      className="motion-link inline-flex items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite)] transition-colors hover:text-[var(--status-green)]"
-                    >
-                      {actionLabel}
-                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                    </a>
-                  )}
-                </div>
-
-                {graph && (
-                  <div className="mt-8 hidden border border-dashed border-[var(--border-dashed)] p-4 lg:block">
-                    {graphLabel && <div className="mb-4 text-drawing-label">{graphLabel}</div>}
-                    <div className="aspect-square overflow-hidden">{graph}</div>
+              <StaggerItem>
+                <aside
+                  className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
+                  aria-label={`${eyebrow} metadata`}
+                >
+                  <div className="grid grid-cols-2 border border-[var(--border-line)]">
+                    {stats.slice(0, 2).map((stat, index) => (
+                      <div
+                        key={stat.label}
+                        className={cn('p-4', index === 0 && 'border-r border-[var(--border-line)]')}
+                      >
+                        <TechnicalLabel>{stat.label}</TechnicalLabel>
+                        <p className="mt-4 font-mono text-3xl text-[var(--graphite)]">
+                          {stat.value}
+                        </p>
+                      </div>
+                    ))}
+                    {latestLabel && latestValue && (
+                      <div className="col-span-2 border-t border-[var(--border-line)] p-4">
+                        <TechnicalLabel>{latestLabel}</TechnicalLabel>
+                        <p className="mt-4 font-mono text-sm uppercase tracking-[0.16em] text-[var(--graphite)]">
+                          {latestValue}
+                        </p>
+                      </div>
+                    )}
                   </div>
-                )}
-              </aside>
-            </div>
+
+                  <div className="mt-8 space-y-4">
+                    <MetadataRow items={metadata} />
+                    {actionHref && (
+                      <a
+                        href={actionHref}
+                        className="motion-link inline-flex items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--graphite)] transition-colors hover:text-[var(--status-green)]"
+                      >
+                        {actionLabel}
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                      </a>
+                    )}
+                  </div>
+
+                  {graph && (
+                    <div className="mt-8 hidden border border-dashed border-[var(--border-dashed)] p-4 lg:block">
+                      {graphLabel && <div className="mb-4 text-drawing-label">{graphLabel}</div>}
+                      <div className="aspect-square overflow-hidden">{graph}</div>
+                    </div>
+                  )}
+                </aside>
+              </StaggerItem>
+            </StaggerGroup>
           </div>
         </FadeInUp>
       </section>

--- a/src/components/design-system/WorkRow.tsx
+++ b/src/components/design-system/WorkRow.tsx
@@ -70,7 +70,7 @@ export default function WorkRow({ item, index }: WorkRowProps) {
                 src={item.image}
                 alt={`${item.title} project preview`}
                 className={cn(
-                  'h-full w-full object-cover grayscale transition duration-300 group-hover/row:opacity-100 group-hover/row:grayscale-0',
+                  'h-full w-full object-cover grayscale transition duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover/row:opacity-100 group-hover/row:grayscale-0 group-hover/row:scale-[1.02] motion-reduce:transition-none motion-reduce:group-hover/row:scale-100',
                   'opacity-70',
                 )}
                 loading="lazy"

--- a/src/components/homepage/ExperienceSection.tsx
+++ b/src/components/homepage/ExperienceSection.tsx
@@ -6,6 +6,7 @@ import ExperienceRow from '@/components/design-system/ExperienceRow'
 import SectionHeader from '@/components/design-system/SectionHeader'
 import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
 import FadeInUp from '@/components/common/FadeInUp'
+import { StaggerGroup, StaggerItem } from '@/components/common/StaggerGroup'
 import { Button } from '@/components/ui/button'
 
 export default function ExperienceSection() {
@@ -80,17 +81,17 @@ export default function ExperienceSection() {
           </div>
         </FadeInUp>
 
-        <FadeInUp delay={0.18}>
-          <div className="relative mt-8 border-t border-[var(--border-line)]">
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
-            />
-            {latestExperiences.map((experience, index) => (
-              <ExperienceRow key={experience.id} experience={experience} index={index} />
-            ))}
-          </div>
-        </FadeInUp>
+        <StaggerGroup className="relative mt-8 border-t border-[var(--border-line)]" initialDelay={0.05}>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+          />
+          {latestExperiences.map((experience, index) => (
+            <StaggerItem key={experience.id}>
+              <ExperienceRow experience={experience} index={index} />
+            </StaggerItem>
+          ))}
+        </StaggerGroup>
       </div>
     </section>
   )

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -1,5 +1,5 @@
 import { Code2 } from "lucide-react";
-import FadeInUp from "@/components/common/FadeInUp";
+import { motion, useReducedMotion, type Variants } from "framer-motion";
 import DrawingFrame from "@/components/design-system/DrawingFrame";
 import MetadataRow from "@/components/design-system/MetadataRow";
 import RouteRail from "@/components/design-system/RouteRail";
@@ -27,13 +27,65 @@ const heroRoutes = [
 
 const heroSkills = ["Product Systems", "Backend Foundations", "Engineering Mentorship"];
 
+const HERO_EASE = [0.22, 1, 0.36, 1] as const;
+
 export default function HeroSection() {
+  const prefersReducedMotion = useReducedMotion();
+
+  const fadeIn: Variants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: { duration: 0.2, ease: HERO_EASE },
+    },
+  };
+
+  const headline: Variants = {
+    hidden: { y: 24, opacity: 0 },
+    visible: {
+      y: 0,
+      opacity: 1,
+      transition: { duration: 0.45, ease: HERO_EASE, delay: 0.08 },
+    },
+  };
+
+  const meta: Variants = {
+    hidden: { y: 12, opacity: 0 },
+    visible: {
+      y: 0,
+      opacity: 1,
+      transition: { duration: 0.3, ease: HERO_EASE, delay: 0.18 },
+    },
+  };
+
+  const panel: Variants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        duration: 0.35,
+        ease: HERO_EASE,
+        delay: 0.05,
+        when: "beforeChildren",
+        staggerChildren: 0.05,
+      },
+    },
+  };
+
+  // When reduced motion is on, render in final state with no transitions.
+  const initial = prefersReducedMotion ? "visible" : "hidden";
+
   return (
     <DrawingFrame
       className="min-h-[calc(100dvh-72px)]"
       innerClassName="min-h-[calc(100dvh-72px)]"
     >
-      <div className="pointer-events-none absolute inset-x-5 top-10 bottom-10 hidden md:block">
+      <motion.div
+        initial={initial}
+        animate="visible"
+        variants={fadeIn}
+        className="pointer-events-none absolute inset-x-5 top-10 bottom-10 hidden md:block"
+      >
         <div className="absolute left-[8%] right-[8%] top-[18%] border-t border-dashed border-[var(--border-dashed)]" />
         <div className="absolute left-[8%] right-[8%] top-[48%] border-t border-dashed border-[var(--border-dashed)]" />
         <div className="absolute left-[8%] right-[8%] bottom-[18%] border-t border-[var(--border-line)]" />
@@ -58,73 +110,86 @@ export default function HeroSection() {
         <span className="coordinate-label absolute left-[7%] bottom-[18%]">
           Y-720
         </span>
-      </div>
+      </motion.div>
 
       <div className="grid min-h-[calc(100dvh-72px)] items-center py-20 md:py-24">
-        <FadeInUp delay={0.12}>
-          <div className="relative mx-auto w-full max-w-[1180px] border border-[var(--border-line)] bg-[var(--hero-panel)] p-5 shadow-[var(--shadow-paper-xs)] backdrop-blur-[2px] md:p-8">
-            <div
-              className="absolute left-0 top-0 h-px w-32 bg-[var(--status-green)]"
-              aria-hidden="true"
-            />
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
-              <div className="space-y-7">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <TechnicalLabel variant="mono">01 // INTRO</TechnicalLabel>
-                  <div className="hidden gap-8 md:flex">
-                    <span className="coordinate-label">X-1024</span>
-                    <span className="coordinate-label">X-768</span>
-                    <span className="coordinate-label">X-480</span>
-                  </div>
-                </div>
-
-                <div className="border border-[var(--border-line)] bg-[var(--hero-title-surface)] px-4 py-5 md:px-6 md:py-7">
-                  <h1 className="text-hero-name text-[var(--graphite)]">
-                    <span>NAUFALDI</span>{" "}
-                    <span className="whitespace-nowrap">RAFIF S.</span>
-                  </h1>
-                </div>
-
-                <div className="max-w-2xl space-y-4 md:pl-6">
-                  <h2 className="font-mono text-2xl leading-tight text-[var(--graphite)] md:text-3xl">
-                    Software Engineer & Mentor
-                  </h2>
-                  <MetadataRow items={heroSkills} />
-                  <p className="text-body-readable">
-                    My foundation is frontend, but the direction is broader:
-                    backend ownership, product architecture, and end-to-end
-                    software delivery.
-                  </p>
+        <motion.div
+          initial={initial}
+          animate="visible"
+          variants={panel}
+          className="relative mx-auto w-full max-w-[1180px] border border-[var(--border-line)] bg-[var(--hero-panel)] p-5 shadow-[var(--shadow-paper-xs)] backdrop-blur-[2px] md:p-8"
+        >
+          <div
+            className="absolute left-0 top-0 h-px w-32 bg-[var(--status-green)]"
+            aria-hidden="true"
+          />
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <div className="space-y-7">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <TechnicalLabel variant="mono">01 // INTRO</TechnicalLabel>
+                <div className="hidden gap-8 md:flex">
+                  <span className="coordinate-label">X-1024</span>
+                  <span className="coordinate-label">X-768</span>
+                  <span className="coordinate-label">X-480</span>
                 </div>
               </div>
 
-              <aside
-                className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
-                aria-label="Hero routes"
+              <motion.div
+                variants={headline}
+                className="border border-[var(--border-line)] bg-[var(--hero-title-surface)] px-4 py-5 md:px-6 md:py-7"
               >
-                <TechnicalLabel variant="mono">02 // ROUTES</TechnicalLabel>
-                <RouteRail items={heroRoutes} ariaLabel="Hero route links" />
-              </aside>
+                <h1 className="text-hero-name text-[var(--graphite)]">
+                  <span>NAUFALDI</span>{" "}
+                  <span className="whitespace-nowrap">RAFIF S.</span>
+                </h1>
+              </motion.div>
+
+              <motion.div
+                variants={meta}
+                className="max-w-2xl space-y-4 md:pl-6"
+              >
+                <h2 className="font-mono text-2xl leading-tight text-[var(--graphite)] md:text-3xl">
+                  Software Engineer & Mentor
+                </h2>
+                <MetadataRow items={heroSkills} />
+                <p className="text-body-readable">
+                  My foundation is frontend, but the direction is broader:
+                  backend ownership, product architecture, and end-to-end
+                  software delivery.
+                </p>
+              </motion.div>
             </div>
 
-            <div className="mt-9 border-t border-[var(--border-line)] pt-5">
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                <MetadataRow
-                  items={[
-                    "Open to work",
-                    `${siteConfig.stats.experience} experience`,
-                    `${siteConfig.stats.mentees} mentees`,
-                    "Bekasi, Indonesia",
-                  ]}
-                />
-                <div className="flex gap-5">
-                  <TechnicalLabel variant="mono">BUILD:2026</TechnicalLabel>
-                  <TechnicalLabel variant="mono">PRD:01</TechnicalLabel>
-                </div>
+            <motion.aside
+              variants={meta}
+              className="border-t border-[var(--border-line)] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0"
+              aria-label="Hero routes"
+            >
+              <TechnicalLabel variant="mono">02 // ROUTES</TechnicalLabel>
+              <RouteRail items={heroRoutes} ariaLabel="Hero route links" />
+            </motion.aside>
+          </div>
+
+          <motion.div
+            variants={meta}
+            className="mt-9 border-t border-[var(--border-line)] pt-5"
+          >
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <MetadataRow
+                items={[
+                  "Open to work",
+                  `${siteConfig.stats.experience} experience`,
+                  `${siteConfig.stats.mentees} mentees`,
+                  "Bekasi, Indonesia",
+                ]}
+              />
+              <div className="flex gap-5">
+                <TechnicalLabel variant="mono">BUILD:2026</TechnicalLabel>
+                <TechnicalLabel variant="mono">PRD:01</TechnicalLabel>
               </div>
             </div>
-          </div>
-        </FadeInUp>
+          </motion.div>
+        </motion.div>
       </div>
     </DrawingFrame>
   );

--- a/src/components/homepage/MentorSpeakerSection.tsx
+++ b/src/components/homepage/MentorSpeakerSection.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/data/mentorSpeaker'
 import MentorSpeakerItem from './MentorSpeakerItem'
 import FadeInUp from '@/components/common/FadeInUp'
+import { StaggerGroup, StaggerItem } from '@/components/common/StaggerGroup'
 import SectionHeader from '@/components/design-system/SectionHeader'
 import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
 import { Button } from '@/components/ui/button'
@@ -80,17 +81,17 @@ export default function MentorSpeakerSection() {
           </div>
         </FadeInUp>
 
-        <FadeInUp delay={0.18}>
-          <div className="relative mt-8 border-t border-[var(--border-line)]">
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
-            />
-            {previewItems.map((item, index) => (
-              <MentorSpeakerItem key={item.id} item={item} index={index} />
-            ))}
-          </div>
-        </FadeInUp>
+        <StaggerGroup className="relative mt-8 border-t border-[var(--border-line)]" initialDelay={0.05}>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+          />
+          {previewItems.map((item, index) => (
+            <StaggerItem key={item.id}>
+              <MentorSpeakerItem item={item} index={index} />
+            </StaggerItem>
+          ))}
+        </StaggerGroup>
       </div>
     </section>
   )

--- a/src/components/homepage/PortfolioSection.tsx
+++ b/src/components/homepage/PortfolioSection.tsx
@@ -5,6 +5,7 @@ import WorkRow from '@/components/design-system/WorkRow'
 import SectionHeader from '@/components/design-system/SectionHeader'
 import { TechnicalLabel } from '@/components/design-system/TechnicalLabel'
 import FadeInUp from '@/components/common/FadeInUp'
+import { StaggerGroup, StaggerItem } from '@/components/common/StaggerGroup'
 import { Button } from '@/components/ui/button'
 
 export default function PortfolioSection() {
@@ -75,17 +76,20 @@ export default function PortfolioSection() {
           </div>
         </FadeInUp>
 
-        <FadeInUp delay={0.18}>
-          <div className="relative mt-8 border-t border-[var(--border-line)] bg-[var(--paper)]/72">
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
-            />
-            {featuredItems.map((item, index) => (
-              <WorkRow key={item.id} item={item} index={index} />
-            ))}
-          </div>
-        </FadeInUp>
+        <StaggerGroup
+          className="relative mt-8 border-t border-[var(--border-line)] bg-[var(--paper)]/72"
+          initialDelay={0.05}
+        >
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-[112px] top-0 hidden h-full border-l border-dashed border-[var(--border-dashed)] md:block lg:left-36"
+          />
+          {featuredItems.map((item, index) => (
+            <StaggerItem key={item.id}>
+              <WorkRow item={item} index={index} />
+            </StaggerItem>
+          ))}
+        </StaggerGroup>
       </div>
     </section>
   )

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -92,25 +92,28 @@ export default function BlogDetail() {
   return (
     <div className="blog-detail-pattern relative flex min-h-screen flex-col bg-[var(--paper)]">
       <div className="site-container relative z-10 w-full py-10 md:py-14">
-        <div className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
-          <Link
-            to="/blogs"
-            className="motion-link group flex items-center justify-between gap-4 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:px-5"
-          >
-            <span className="inline-flex items-center gap-2">
-              <ArrowLeft
-                className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
-                aria-hidden="true"
-              />
-              route:/blogs
-            </span>
-            <span className="hidden text-[var(--status-green)] sm:inline">
-              return_index
-            </span>
-          </Link>
-        </div>
+        <FadeInUp delay={0.02} duration={0.32}>
+          <div className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+            <Link
+              to="/blogs"
+              className="motion-link group flex items-center justify-between gap-4 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:px-5"
+            >
+              <span className="inline-flex items-center gap-2">
+                <ArrowLeft
+                  className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+                  aria-hidden="true"
+                />
+                route:/blogs
+              </span>
+              <span className="hidden text-[var(--status-green)] sm:inline">
+                return_index
+              </span>
+            </Link>
+          </div>
+        </FadeInUp>
 
-        <section className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+        <FadeInUp delay={0.06} duration={0.34}>
+          <section className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
           <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
             <span>02 // BLOG_META</span>
             <span>BUILD:2026</span>
@@ -165,7 +168,8 @@ export default function BlogDetail() {
             <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
             ARTICLE_READY
           </div>
-        </section>
+          </section>
+        </FadeInUp>
 
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="min-w-0">

--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { FileText } from "lucide-react";
 import { getBlogsByCategory, type BlogCategory } from "@/data/blogs";
 import BlogCard from "@/components/blogs/BlogCard";
+import FadeInUp from "@/components/common/FadeInUp";
+import { StaggerGroup, StaggerItem } from "@/components/common/StaggerGroup";
 import BlueprintIndexHero from "@/components/design-system/BlueprintIndexHero";
 import { cn } from "@/lib";
 import {
@@ -105,53 +107,54 @@ export default function Blogs() {
       </div>
 
       <div className="site-container relative z-10">
+        <FadeInUp delay={0.04}>
+          <section className="border-b border-[var(--border-line)]">
+            <div className="grid grid-cols-1 gap-6 py-6 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
+              <div className="text-drawing-label">
+                03 // ROUTES
+              </div>
 
-        <section className="border-b border-[var(--border-line)]">
-          <div className="grid grid-cols-1 gap-6 py-6 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
-            <div className="text-drawing-label">
-              03 // ROUTES
+              <div
+                className="grid grid-cols-2 border border-[var(--border-line)] sm:flex"
+                role="tablist"
+                aria-label="Filter blog posts by category"
+              >
+                {categories.map((category) => {
+                  const isActive = selectedCategory === category;
+
+                  return (
+                    <button
+                      key={category}
+                      role="tab"
+                      aria-selected={isActive}
+                      aria-controls="blog-feed"
+                      onClick={() => setSelectedCategory(category)}
+                      className={cn(
+                        "motion-button group relative min-h-12 border-b border-r border-[var(--border-line)] px-4 py-3 text-left font-mono text-[11px] uppercase tracking-[0.18em] transition-colors duration-200 last:border-r-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:border-b-0",
+                        isActive
+                          ? "bg-[var(--graphite)] text-[var(--paper)]"
+                          : "bg-[var(--paper)] text-[var(--graphite-muted)] hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)]"
+                      )}
+                    >
+                      <span className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            "h-1.5 w-1.5 rounded-full transition-colors",
+                            isActive
+                              ? "bg-[#22c55e]"
+                              : "bg-[var(--border-strong)]"
+                          )}
+                          aria-hidden="true"
+                        />
+                        {formatCategoryLabel(category)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-
-            <div
-              className="grid grid-cols-2 border border-[var(--border-line)] sm:flex"
-              role="tablist"
-              aria-label="Filter blog posts by category"
-            >
-              {categories.map((category) => {
-                const isActive = selectedCategory === category;
-
-                return (
-                  <button
-                    key={category}
-                    role="tab"
-                    aria-selected={isActive}
-                    aria-controls="blog-feed"
-                    onClick={() => setSelectedCategory(category)}
-                    className={cn(
-                      "motion-button group relative min-h-12 border-b border-r border-[var(--border-line)] px-4 py-3 text-left font-mono text-[11px] uppercase tracking-[0.18em] transition-colors duration-200 last:border-r-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:border-b-0",
-                      isActive
-                        ? "bg-[var(--graphite)] text-[var(--paper)]"
-                        : "bg-[var(--paper)] text-[var(--graphite-muted)] hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)]"
-                    )}
-                  >
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          "h-1.5 w-1.5 rounded-full transition-colors",
-                          isActive
-                            ? "bg-[#22c55e]"
-                            : "bg-[var(--border-strong)]"
-                        )}
-                        aria-hidden="true"
-                      />
-                      {formatCategoryLabel(category)}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </section>
+          </section>
+        </FadeInUp>
 
         <div className="sr-only" aria-live="polite" role="status">
           {filteredBlogs.length === 0
@@ -166,52 +169,63 @@ export default function Blogs() {
           className="border-b border-[var(--border-line)]"
         >
           {paginatedBlogs.length === 0 ? (
-            <div className="grid grid-cols-1 gap-6 py-16 lg:grid-cols-[170px_minmax(0,1fr)]">
-              <div className="text-drawing-label">
-                00 // EMPTY
+            <FadeInUp key={`${selectedCategory}-empty`}>
+              <div className="grid grid-cols-1 gap-6 py-16 lg:grid-cols-[170px_minmax(0,1fr)]">
+                <div className="text-drawing-label">
+                  00 // EMPTY
+                </div>
+                <div className="border border-dashed border-[var(--border-dashed)] px-6 py-12">
+                  <FileText
+                    className="mb-5 h-8 w-8 text-[var(--graphite-muted)]"
+                    aria-hidden="true"
+                  />
+                  <h2 className="font-mono text-2xl text-[var(--graphite)]">
+                    No entries on this route
+                  </h2>
+                  <p className="mt-3 max-w-xl font-body text-sm font-medium leading-7 text-[var(--graphite-muted)]">
+                    Try another category rail to inspect the rest of the writing
+                    archive.
+                  </p>
+                </div>
               </div>
-              <div className="border border-dashed border-[var(--border-dashed)] px-6 py-12">
-                <FileText
-                  className="mb-5 h-8 w-8 text-[var(--graphite-muted)]"
-                  aria-hidden="true"
-                />
-                <h2 className="font-mono text-2xl text-[var(--graphite)]">
-                  No entries on this route
-                </h2>
-                <p className="mt-3 max-w-xl font-body text-sm font-medium leading-7 text-[var(--graphite-muted)]">
-                  Try another category rail to inspect the rest of the writing
-                  archive.
-                </p>
-              </div>
-            </div>
+            </FadeInUp>
           ) : (
-            paginatedBlogs.map((blog, index) => (
-              <BlogCard key={blog.id} blog={blog} index={startIndex + index} />
-            ))
+            <StaggerGroup
+              key={`${selectedCategory}-${currentPage}`}
+              staggerDelay={0.045}
+              initialDelay={0.03}
+            >
+              {paginatedBlogs.map((blog, index) => (
+                <StaggerItem key={blog.id}>
+                  <BlogCard blog={blog} index={startIndex + index} />
+                </StaggerItem>
+              ))}
+            </StaggerGroup>
           )}
         </section>
 
         {totalPages > 1 && (
-          <section className="grid grid-cols-1 gap-6 py-7 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
-            <div className="text-drawing-label">
-              04 // PAGE_CTRL
-            </div>
-
-            <div className="flex flex-col gap-4 border border-[var(--border-line)] bg-[var(--hero-panel)] p-3 md:flex-row md:items-center md:justify-between">
-              <div className="px-2 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--graphite-muted)]">
-                Page {String(currentPage).padStart(2, "0")} /{" "}
-                {String(totalPages).padStart(2, "0")}
+          <FadeInUp delay={0.04}>
+            <section className="grid grid-cols-1 gap-6 py-7 lg:grid-cols-[170px_minmax(0,1fr)] lg:items-center">
+              <div className="text-drawing-label">
+                04 // PAGE_CTRL
               </div>
 
-              <Pagination className="mx-0 w-full justify-start md:w-auto md:justify-end">
-                <PaginationContent className="flex-wrap justify-start gap-1 md:justify-end">
-                  <PaginationItem>
-                    <PaginationPrevious
-                      onClick={() => handlePageChange(currentPage - 1)}
-                      disabled={currentPage === 1}
-                      className="h-10 rounded-none border-[var(--border-line)] bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none"
-                    />
-                  </PaginationItem>
+              <div className="flex flex-col gap-4 border border-[var(--border-line)] bg-[var(--hero-panel)] p-3 md:flex-row md:items-center md:justify-between">
+                <div className="px-2 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--graphite-muted)]">
+                  Page {String(currentPage).padStart(2, "0")} /{" "}
+                  {String(totalPages).padStart(2, "0")}
+                </div>
+
+                <Pagination className="mx-0 w-full justify-start md:w-auto md:justify-end">
+                  <PaginationContent className="flex-wrap justify-start gap-1 md:justify-end">
+                    <PaginationItem>
+                      <PaginationPrevious
+                        onClick={() => handlePageChange(currentPage - 1)}
+                        disabled={currentPage === 1}
+                        className="h-10 rounded-none border-[var(--border-line)] bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none"
+                      />
+                    </PaginationItem>
 
                   {Array.from(
                     {
@@ -249,17 +263,18 @@ export default function Blogs() {
                     return null;
                   })}
 
-                  <PaginationItem>
-                    <PaginationNext
-                      onClick={() => handlePageChange(currentPage + 1)}
-                      disabled={currentPage === totalPages}
-                      className="h-10 rounded-none border-[var(--border-line)] bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none"
-                    />
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-            </div>
-          </section>
+                    <PaginationItem>
+                      <PaginationNext
+                        onClick={() => handlePageChange(currentPage + 1)}
+                        disabled={currentPage === totalPages}
+                        className="h-10 rounded-none border-[var(--border-line)] bg-transparent px-4 font-mono text-[11px] uppercase tracking-[0.18em] shadow-none"
+                      />
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            </section>
+          </FadeInUp>
         )}
       </div>
     </div>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -61,80 +61,84 @@ export default function ProjectDetail() {
   return (
     <div className="project-detail-pattern relative flex min-h-screen flex-col bg-[var(--paper)]">
       <div className="site-container relative z-10 w-full py-10 md:py-14">
-        <div className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
-          <Link
-            to="/projects"
-            className="motion-link group flex items-center justify-between gap-4 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:px-5"
-          >
-            <span className="inline-flex items-center gap-2">
-              <ArrowLeft
-                className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
-                aria-hidden="true"
-              />
-              route:/projects
-            </span>
-            <span className="hidden text-[var(--status-green)] sm:inline">
-              return_index
-            </span>
-          </Link>
-        </div>
-
-        <section className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
-          <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
-            <span>02 // PROJECT_META</span>
-            <span>BUILD:2026</span>
+        <FadeInUp delay={0.02} duration={0.32}>
+          <div className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+            <Link
+              to="/projects"
+              className="motion-link group flex items-center justify-between gap-4 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--graphite-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--graphite)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-strong)] sm:px-5"
+            >
+              <span className="inline-flex items-center gap-2">
+                <ArrowLeft
+                  className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+                  aria-hidden="true"
+                />
+                route:/projects
+              </span>
+              <span className="hidden text-[var(--status-green)] sm:inline">
+                return_index
+              </span>
+            </Link>
           </div>
+        </FadeInUp>
 
-          <div className="grid gap-px bg-[var(--border-line)] sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1.4fr_1.2fr]">
-            <div className="bg-[var(--paper)] px-3 py-3">
-              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
-                Type
-              </div>
-              <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
-                {project.type === "blog" ? "TECHNICAL_BLOG" : "PROJECT"}
-              </div>
+        <FadeInUp delay={0.06} duration={0.34}>
+          <section className="mb-6 border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+            <div className="flex flex-col gap-2 border-b border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--graphite-muted)] sm:flex-row sm:items-center sm:justify-between">
+              <span>02 // PROJECT_META</span>
+              <span>BUILD:2026</span>
             </div>
-            <div className="bg-[var(--paper)] px-3 py-3">
-              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
-                Published
-              </div>
-              <div className="mt-1.5 font-mono text-[13px] uppercase tracking-[0.14em] text-[var(--graphite)]">
-                {formatDate(project.date)}
-              </div>
-            </div>
-            <div className="bg-[var(--paper)] px-3 py-3">
-              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
-                Stack
-              </div>
-              <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
-                {project.techStack.slice(0, 3).map(formatStackLabel).join(" / ")}
-              </div>
-            </div>
-            <div className="bg-[var(--paper)] px-3 py-3">
-              <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
-                Pipeline
-              </div>
-              <div className="mt-2 flex flex-wrap items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em]">
-                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
-                  MD
-                </span>
-                <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
-                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
-                  ROUTE
-                </span>
-                <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
-                <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--status-green)]">
-                  UI
-                </span>
-              </div>
-            </div>
-          </div>
 
-          <div className="flex items-center gap-2 border-t border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--status-green)]">
-            <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
-            PROJECT_READY
-          </div>
-        </section>
+            <div className="grid gap-px bg-[var(--border-line)] sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1.4fr_1.2fr]">
+              <div className="bg-[var(--paper)] px-3 py-3">
+                <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                  Type
+                </div>
+                <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
+                  {project.type === "blog" ? "TECHNICAL_BLOG" : "PROJECT"}
+                </div>
+              </div>
+              <div className="bg-[var(--paper)] px-3 py-3">
+                <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                  Published
+                </div>
+                <div className="mt-1.5 font-mono text-[13px] uppercase tracking-[0.14em] text-[var(--graphite)]">
+                  {formatDate(project.date)}
+                </div>
+              </div>
+              <div className="bg-[var(--paper)] px-3 py-3">
+                <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                  Stack
+                </div>
+                <div className="mt-1.5 truncate font-mono text-[13px] uppercase tracking-[0.12em] text-[var(--graphite)]">
+                  {project.techStack.slice(0, 3).map(formatStackLabel).join(" / ")}
+                </div>
+              </div>
+              <div className="bg-[var(--paper)] px-3 py-3">
+                <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--graphite-muted)]">
+                  Pipeline
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em]">
+                  <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
+                    MD
+                  </span>
+                  <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
+                  <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--graphite-muted)]">
+                    ROUTE
+                  </span>
+                  <span className="hidden h-px min-w-8 flex-1 border-t border-dashed border-[var(--border-dashed)] sm:block" />
+                  <span className="border border-[var(--border-line)] px-2 py-1 text-[var(--status-green)]">
+                    UI
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 border-t border-[var(--border-line)] px-3 py-2.5 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--status-green)]">
+              <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-green)]" />
+              PROJECT_READY
+            </div>
+          </section>
+        </FadeInUp>
 
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="flex-1 min-w-0">

--- a/src/pages/ShortDetail.tsx
+++ b/src/pages/ShortDetail.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useParams } from 'react-router'
 import { ArrowLeft } from 'lucide-react'
+import FadeInUp from '@/components/common/FadeInUp'
 import MarkdownRenderer from '@/components/shorts/MarkdownRenderer'
 import { Button } from '@/components/ui/button'
 import DrawingFrame from '@/components/design-system/DrawingFrame'
@@ -32,53 +33,57 @@ export default function ShortDetail() {
     <div className="relative flex min-h-screen flex-col bg-[var(--paper)] text-[var(--graphite)]">
       <DrawingFrame className="py-10 md:py-14">
         <div className="mx-auto max-w-5xl">
-          <Button
-            type="button"
-            variant="technical"
-            onClick={() => navigate('/shorts')}
-            className="mb-8"
-          >
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Back to shorts
-          </Button>
+          <FadeInUp delay={0.02} duration={0.32}>
+            <Button
+              type="button"
+              variant="technical"
+              onClick={() => navigate('/shorts')}
+              className="mb-8"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              Back to shorts
+            </Button>
+          </FadeInUp>
 
-          <article className="border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
-            <header className="grid gap-px bg-[var(--border-line)] md:grid-cols-[minmax(0,1fr)_280px]">
-              <div className="bg-[var(--paper)] p-5 md:p-8">
-                <div className="text-drawing-label">01 // SHORT_DETAIL</div>
-                <h1 className="mt-8 max-w-3xl font-mono text-4xl font-semibold leading-tight text-[var(--graphite)] md:text-6xl">
-                  {short.title}
-                </h1>
+          <FadeInUp delay={0.06}>
+            <article className="border border-[var(--border-line)] bg-[var(--paper)] shadow-[var(--shadow-paper-xs)]">
+              <header className="grid gap-px bg-[var(--border-line)] md:grid-cols-[minmax(0,1fr)_280px]">
+                <div className="bg-[var(--paper)] p-5 md:p-8">
+                  <div className="text-drawing-label">01 // SHORT_DETAIL</div>
+                  <h1 className="mt-8 max-w-3xl font-mono text-4xl font-semibold leading-tight text-[var(--graphite)] md:text-6xl">
+                    {short.title}
+                  </h1>
 
-                {short.tags.length > 0 && (
-                  <div className="mt-8 flex flex-wrap items-center gap-2">
-                    {short.tags.map((tag) => (
-                      <TechnicalLabel key={tag} variant="outline">
-                        {tag}
-                      </TechnicalLabel>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <aside className="bg-[var(--paper)] p-5 md:p-8" aria-label="Short metadata">
-                <TechnicalLabel variant="status">DETAIL_READY</TechnicalLabel>
-                <div className="mt-8">
-                  <MetadataRow
-                    items={[
-                      `route: /shorts/${short.slug}`,
-                      `date: ${short.date}`,
-                      `tags: ${short.tags.length}`,
-                    ]}
-                  />
+                  {short.tags.length > 0 && (
+                    <div className="mt-8 flex flex-wrap items-center gap-2">
+                      {short.tags.map((tag) => (
+                        <TechnicalLabel key={tag} variant="outline">
+                          {tag}
+                        </TechnicalLabel>
+                      ))}
+                    </div>
+                  )}
                 </div>
-              </aside>
-            </header>
 
-            <div className="prose prose-invert light:prose-light max-w-none p-5 md:p-8">
-              <MarkdownRenderer content={short.content} />
-            </div>
-          </article>
+                <aside className="bg-[var(--paper)] p-5 md:p-8" aria-label="Short metadata">
+                  <TechnicalLabel variant="status">DETAIL_READY</TechnicalLabel>
+                  <div className="mt-8">
+                    <MetadataRow
+                      items={[
+                        `route: /shorts/${short.slug}`,
+                        `date: ${short.date}`,
+                        `tags: ${short.tags.length}`,
+                      ]}
+                    />
+                  </div>
+                </aside>
+              </header>
+
+              <div className="prose prose-invert light:prose-light max-w-none p-5 md:p-8">
+                <MarkdownRenderer content={short.content} />
+              </div>
+            </article>
+          </FadeInUp>
         </div>
       </DrawingFrame>
     </div>


### PR DESCRIPTION
## What Change

- Added a shared Framer Motion route transition in `Layout` for page-to-page crossfade and slight vertical settle.
- Refined the shared observer reveal helper and added `StaggerGroup`/`StaggerItem` for consistent section and list choreography.
- Updated blueprint hero components so index and command heroes reveal title, metadata, route rails, and footer/status content in a consistent order.
- Replaced the Blog feed inline CSS animation with shared staggered observer motion and kept cards interactive.
- Added calm detail-page shell reveals for blog, project, and short pages without animating long-form content paragraphs.

## Why Change

- Fulfills the site-wide subtle animation pass requested for smoother first-view, route, and observer-based transitions across public pages.
- Previous motion behavior was split between one-off inline animation, custom homepage choreography, and partial `FadeInUp` usage; this makes the motion system consistent and reusable.
- Keeps the existing blueprint/paper design direction while making transitions feel less abrupt.

## Impact

- **Affected areas:** Layout route rendering, shared motion helpers, blueprint heroes, homepage sections, blog/project/short detail shells, and the blog index feed.
- **Breaking changes:** No.
- **Dependencies:** No new dependencies; reuses existing `framer-motion`.
- **Testing:** `bun run build`; local browser sweep across `/`, `/blogs`, `/projects`, `/about`, `/speaker`, `/book`, `/manhwa`, `/shorts`, representative detail routes, and a missing route; desktop/mobile screenshots checked for obvious layout overlap.